### PR TITLE
avoids conflicts between kube envs vs app envs

### DIFF
--- a/hypertrace-graphql-service/src/main/resources/configs/common/application.conf
+++ b/hypertrace-graphql-service/src/main/resources/configs/common/application.conf
@@ -11,14 +11,14 @@ defaultTenantId = ${?DEFAULT_TENANT_ID}
 
 attribute.service = {
   host = localhost
-  host = ${?ATTRIBUTE_SERVICE_HOST}
+  host = ${?ATTRIBUTE_SERVICE_HOST_CONFIG}
   port = 9012
-  port = ${?ATTRIBUTE_SERVICE_PORT}
+  port = ${?ATTRIBUTE_SERVICE_PORT_CONFIG}
 }
 
 gateway.service = {
   host = localhost
-  host = ${?GATEWAY_SERVICE_HOST}
+  host = ${?GATEWAY_SERVICE_HOST_CONFIG}
   port = 50071
-  port = ${?GATEWAY_SERVICE_PORT}
+  port = ${?GATEWAY_SERVICE_PORT_CONFIG}
 }


### PR DESCRIPTION
- kube sets default env for service port as <service_name>_port e.g `ATTRIBUTE_SERVICE_PORT. So, we decided to add  `_CONFIG` for app-related host/port config to avoid conflicts.