### PR TITLE
removes name based service discovery

### DIFF
--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -8,8 +8,6 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
       protocol: TCP
-      name: http
   selector:
     {{- toYaml .Values.serviceSelectorLabels | nindent 4 }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -8,6 +8,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
+      targetPort: http
       protocol: TCP
   selector:
     {{- toYaml .Values.serviceSelectorLabels | nindent 4 }}


### PR DESCRIPTION
kube internally uses `name: http` property for service discovery, this was causing issue with `serviceSelectorLabels` via diverting traffic to federated service in helm setup. So, like any other service, removing it.