### PR TITLE
Adds one line description and key queries in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ GraphQL Service runs on port 23431 at `/graphql` by default
 
 
 ## Queries
-Here are some of the important graphql queries:
+Here are some of the important GraphQL queries:
 
 ### 1. Get all traces in provided time range
 
 ```graphql
-curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d\
+curl -s localhost:2020/graphql -H 'Content-Type: application/graphql' -d\
 '{
   traces(
     type: API_TRACE
@@ -39,7 +39,7 @@ curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d\
 ### 2. Find trace using TraceID
 
 ```graphql
-curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
+curl -s localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
 '{
   traces(
     type: API_TRACE
@@ -67,7 +67,7 @@ curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d 
 ### 3. Get all services your application is using
 
 ```graphql
-curl -s http://localhost:2020/graphql  -H 'Content-Type: application/graphql' -d \
+curl -s localhost:2020/graphql  -H 'Content-Type: application/graphql' -d \
 '{
   entities(
     type: SERVICE 
@@ -78,7 +78,6 @@ curl -s http://localhost:2020/graphql  -H 'Content-Type: application/graphql' -d
     offset: 0
   ) {
     results {
-      id
       name: attribute(key: "name")
     }
     total
@@ -89,7 +88,7 @@ curl -s http://localhost:2020/graphql  -H 'Content-Type: application/graphql' -d
 ### 4. Get all backends your application is using
 
 ```graphql
-curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
+curl -s localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
 '{
   entities(
     type: BACKEND
@@ -100,7 +99,6 @@ curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d 
     offset: 0
   ) {
     results {
-      id
       name: attribute(key: "name")
     }
     total
@@ -111,7 +109,7 @@ curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d 
 ### 5. Get all API's your application is using
 
 ```graphql
-curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
+curl -s localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
 '{
   entities(
     type: API
@@ -122,7 +120,6 @@ curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d 
     offset: 0
   ) {
     results {
-      id
       name: attribute(key: "name")
     }
     total
@@ -133,7 +130,7 @@ curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d 
 ### 6. Get service and backend dependency graph
 
 ```graphql
-curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
+curl -s localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
 '{
   entities(
     type: SERVICE
@@ -149,7 +146,6 @@ curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d 
       outgoingEdges_SERVICE: outgoingEdges(neighborType: SERVICE) {
         results {
           neighbor {
-            id
             name: attribute(key: "name")
           }
         }
@@ -157,7 +153,6 @@ curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d 
       outgoingEdges_BACKEND: outgoingEdges(neighborType: BACKEND) {
         results {
           neighbor {
-            id
             name: attribute(key: "name")
           }
         }
@@ -165,7 +160,6 @@ curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d 
       incomingEdges_SERVICE: incomingEdges(neighborType: SERVICE) {
         results {
           neighbor {
-            id
             name: attribute(key: "name")
           }
         }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Here are some of the important graphql queries:
 
 ### 1. Get all traces in provided time range
 
-```curl
+```graphql
 curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d\
 '{
   traces(
@@ -38,7 +38,7 @@ curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d\
 
 ### 2. Find trace using TraceID
 
-```curl
+```graphql
 curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
 '{
   traces(
@@ -65,7 +65,7 @@ curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
 
 ### 3. Get all services your application is using
 
-```curl
+```graphql
 curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
 '{
   entities(
@@ -87,7 +87,7 @@ curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
 
 ### 4. Get all backends your application is using
 
-```curl
+```graphql
 curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
 '{
   entities(
@@ -109,7 +109,7 @@ curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
 
 ### 5. Get all API's your application is using
 
-```curl
+```graphql
 curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
 '{
   entities(
@@ -131,7 +131,7 @@ curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
 
 ### 6. Get service and backend dependency graph
 
-```curl
+```graphql
 curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
 '{
   entities(

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Hypertrace GraphQL
-
+Hypertrace GraphQL service serves the GraphQL API which will be used by Hypertrace UI.
 
 ## Testing
 
@@ -13,3 +13,163 @@
 
 GraphQL Service runs on port 23431 at `/graphql` by default
 
+
+## Queries
+Here are some of the important graphql queries:
+
+### 1. Get all traces in provided time range
+
+```curl
+curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d\
+'{
+  traces(
+    type: API_TRACE
+    between: {
+      startTime: "2015-01-01T00:00:00.000Z"
+      endTime: "2025-01-01T00:00:00.000Z"
+    }
+  ) {
+    results {
+      id
+    }
+  }
+}'
+```
+
+### 2. Find trace using TraceID
+
+```curl
+curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
+'{
+  traces(
+    type: API_TRACE
+    between: {
+      startTime: "2015-01-01T00:00:00.000Z"
+      endTime: "2025-01-01T00:00:00.000Z"
+    }
+    filterBy: [
+      {
+        operator: EQUALS
+        value: "431fd38511f63001"
+        type: ID
+        idType: API_TRACE
+      }
+    ]
+  ) {
+    results {
+      id
+    }
+  }
+}'
+```
+
+### 3. Get all services your application is using
+
+```curl
+curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
+'{
+  entities(
+    type: SERVICE 
+    between: {
+      startTime: "2015-01-01T00:00:00Z"
+      endTime: "2025-01-01T00:00:00Z"
+    }
+    offset: 0
+  ) {
+    results {
+      id
+      name: attribute(key: "name")
+    }
+    total
+  }
+}'
+```
+
+### 4. Get all backends your application is using
+
+```curl
+curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
+'{
+  entities(
+    type: BACKEND
+    between: {
+      startTime: "2015-01-01T00:00:00Z"
+      endTime: "2025-01-01T00:00:00Z"
+    }
+    offset: 0
+  ) {
+    results {
+      id
+      name: attribute(key: "name")
+    }
+    total
+  }
+}'
+```
+
+### 5. Get all API's your application is using
+
+```curl
+curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
+'{
+  entities(
+    type: API
+    between: {
+      startTime: "2015-01-01T00:00:00Z"
+      endTime: "2025-01-01T00:00:00Z"
+    }
+    offset: 0
+  ) {
+    results {
+      id
+      name: attribute(key: "name")
+    }
+    total
+  }
+}'
+```
+
+### 6. Get service and backend dependency graph
+
+```curl
+curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
+'{
+  entities(
+    type: SERVICE
+    limit: 100
+    between: {
+      startTime: "2015-01-01T00:00:00.000Z"
+      endTime: "2025-01-01T00:00:00.000Z"
+    }
+  ) {
+    results {
+      id
+      name: attribute(key: "name")
+      outgoingEdges_SERVICE: outgoingEdges(neighborType: SERVICE) {
+        results {
+          neighbor {
+            id
+            name: attribute(key: "name")
+          }
+        }
+      }
+      outgoingEdges_BACKEND: outgoingEdges(neighborType: BACKEND) {
+        results {
+          neighbor {
+            id
+            name: attribute(key: "name")
+          }
+        }
+      }
+      incomingEdges_SERVICE: incomingEdges(neighborType: SERVICE) {
+        results {
+          neighbor {
+            id
+            name: attribute(key: "name")
+          }
+        }
+      }
+    }
+  }
+}'
+```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Here are some of the important graphql queries:
 ### 1. Get all traces in provided time range
 
 ```graphql
-curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d\
+curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d\
 '{
   traces(
     type: API_TRACE
@@ -39,7 +39,7 @@ curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d\
 ### 2. Find trace using TraceID
 
 ```graphql
-curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
+curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
 '{
   traces(
     type: API_TRACE
@@ -50,7 +50,7 @@ curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
     filterBy: [
       {
         operator: EQUALS
-        value: "431fd38511f63001"
+        value: "348bae39282251a5"
         type: ID
         idType: API_TRACE
       }
@@ -58,6 +58,7 @@ curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
   ) {
     results {
       id
+      apiName: attribute(key: "apiName") 
     }
   }
 }'
@@ -66,7 +67,7 @@ curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
 ### 3. Get all services your application is using
 
 ```graphql
-curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
+curl -s http://localhost:2020/graphql  -H 'Content-Type: application/graphql' -d \
 '{
   entities(
     type: SERVICE 
@@ -88,7 +89,7 @@ curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
 ### 4. Get all backends your application is using
 
 ```graphql
-curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
+curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
 '{
   entities(
     type: BACKEND
@@ -110,7 +111,7 @@ curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
 ### 5. Get all API's your application is using
 
 ```graphql
-curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
+curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
 '{
   entities(
     type: API
@@ -132,7 +133,7 @@ curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
 ### 6. Get service and backend dependency graph
 
 ```graphql
-curl 'http://localhost:2020/graphql' -H 'Content-Type: application/graphql' -d \
+curl -s http://localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
 '{
   entities(
     type: SERVICE

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ curl -s localhost:2020/graphql -H 'Content-Type: application/graphql' -d\
 }'
 ```
 
-### 2. Find trace using TraceID
+### 2. Verify trace exists
 
 ```graphql
 curl -s localhost:2020/graphql -H 'Content-Type: application/graphql' -d \

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ curl -s localhost:2020/graphql -H 'Content-Type: application/graphql' -d\
 '{
   traces(
     type: API_TRACE
+    limit: 10
     between: {
       startTime: "2015-01-01T00:00:00.000Z"
       endTime: "2025-01-01T00:00:00.000Z"

--- a/README.md
+++ b/README.md
@@ -9,11 +9,6 @@ Hypertrace GraphQL service serves the GraphQL API which will be used by Hypertra
 
 `./gradlew run`
 
-## Ports
-
-GraphQL Service runs on port 23431 at `/graphql` by default
-
-
 ## Queries
 Here are some of the important GraphQL queries:
 
@@ -58,14 +53,13 @@ curl -s localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
     ]
   ) {
     results {
-      id
       apiName: attribute(key: "apiName") 
     }
   }
 }'
 ```
 
-### 3. Get all services your application is using
+### 3. Get all service names
 
 ```graphql
 curl -s localhost:2020/graphql  -H 'Content-Type: application/graphql' -d \
@@ -76,7 +70,6 @@ curl -s localhost:2020/graphql  -H 'Content-Type: application/graphql' -d \
       startTime: "2015-01-01T00:00:00Z"
       endTime: "2025-01-01T00:00:00Z"
     }
-    offset: 0
   ) {
     results {
       name: attribute(key: "name")
@@ -86,7 +79,7 @@ curl -s localhost:2020/graphql  -H 'Content-Type: application/graphql' -d \
 }'
 ```
 
-### 4. Get all backends your application is using
+### 4. Get all backend names
 
 ```graphql
 curl -s localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
@@ -97,7 +90,6 @@ curl -s localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
       startTime: "2015-01-01T00:00:00Z"
       endTime: "2025-01-01T00:00:00Z"
     }
-    offset: 0
   ) {
     results {
       name: attribute(key: "name")
@@ -107,7 +99,7 @@ curl -s localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
 }'
 ```
 
-### 5. Get all API's your application is using
+### 5. Get all API names
 
 ```graphql
 curl -s localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
@@ -118,7 +110,6 @@ curl -s localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
       startTime: "2015-01-01T00:00:00Z"
       endTime: "2025-01-01T00:00:00Z"
     }
-    offset: 0
   ) {
     results {
       name: attribute(key: "name")
@@ -135,7 +126,6 @@ curl -s localhost:2020/graphql -H 'Content-Type: application/graphql' -d \
 '{
   entities(
     type: SERVICE
-    limit: 100
     between: {
       startTime: "2015-01-01T00:00:00.000Z"
       endTime: "2025-01-01T00:00:00.000Z"


### PR DESCRIPTION
- Added one line description for GraphQL service.
- Added queries section which lists key queries across main screens including:
   - Get all traces in provided time range
   - Find trace using TraceID
   - Get all services your application is using
   - Get all backends your application is using
   - Get all API's your application is using
   - Get service and backend dependency graph