### PR TITLE
fix: NPE for service name getter

### DIFF
--- a/hypertrace-graphql-service/src/main/java/org/hypertrace/graphql/service/GraphQlService.java
+++ b/hypertrace-graphql-service/src/main/java/org/hypertrace/graphql/service/GraphQlService.java
@@ -66,9 +66,4 @@ public class GraphQlService extends PlatformService {
   public boolean healthCheck() {
     return true;
   }
-
-  @Override
-  public String getServiceName() {
-    return graphQlServiceImpl.getGraphQlServiceConfig().getServiceName();
-  }
 }


### PR DESCRIPTION
Observed after updating platform service framework dependency