### PR TITLE
fix: snyk ionetty vulberability warning

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,6 +1,10 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.14.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore: {}
+ignore:
+  SNYK-JAVA-IONETTY-1042268:
+    - '*':
+        reason: No replacement available
+        expires: 2021-01-31T00:00:00.000Z
 patch: {}
 


### PR DESCRIPTION
Ignore it in .snyk file since there is no patch for it
