### PR TITLE
fix: switch typo in explorer scope arg 'string' -> 'scope'

### DIFF
--- a/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/schema/argument/ExplorerScopeArgument.java
+++ b/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/schema/argument/ExplorerScopeArgument.java
@@ -3,5 +3,5 @@ package org.hypertrace.graphql.explorer.schema.argument;
 import org.hypertrace.core.graphql.deserialization.PrimitiveArgument;
 
 public interface ExplorerScopeArgument extends PrimitiveArgument<String> {
-  String ARGUMENT_NAME = "string";
+  String ARGUMENT_NAME = "scope";
 }


### PR DESCRIPTION
## Description
This was a typo in the explorer api's arg names that hadn't been hit yet because the UI still uses the deprecated path.

### Testing
Manually verified the corrected name works

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

