### PR TITLE
chore: remove unused deprecated code, deprecate more

### DIFF
--- a/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/schema/Entity.java
+++ b/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/schema/Entity.java
@@ -1,6 +1,5 @@
 package org.hypertrace.graphql.entity.schema;
 
-import graphql.annotations.annotationTypes.GraphQLDeprecate;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLNonNull;
@@ -12,8 +11,7 @@ import org.hypertrace.graphql.entity.schema.argument.NeighborEntityTypeArgument;
 import org.hypertrace.graphql.metric.schema.MetricQueryable;
 
 @GraphQLName(Entity.TYPE_NAME)
-public interface Entity
-    extends AttributeQueryable, MetricQueryable, Identifiable, Typed<String> {
+public interface Entity extends AttributeQueryable, MetricQueryable, Identifiable, Typed<String> {
   String TYPE_NAME = "Entity";
   String ENTITY_INCOMING_EDGES_KEY = "incomingEdges";
   String ENTITY_OUTGOING_EDGES_KEY = "outgoingEdges";

--- a/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/schema/EntitySchema.java
+++ b/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/schema/EntitySchema.java
@@ -25,7 +25,7 @@ public interface EntitySchema {
   @GraphQLName(ENTITIES_QUERY_NAME)
   @GraphQLDataFetcher(EntityFetcher.class)
   EntityResultSet entities(
-      @GraphQLName(EntityTypeArgument.ARGUMENT_NAME) EntityType entityType,
+      @Deprecated @GraphQLName(EntityTypeArgument.ARGUMENT_NAME) EntityType entityType,
       @GraphQLName(EntityScopeArgument.ARGUMENT_NAME) String entityScope,
       @GraphQLName(TimeRangeArgument.ARGUMENT_NAME) @GraphQLNonNull TimeRangeArgument timeRange,
       @GraphQLName(SpaceArgument.ARGUMENT_NAME) String space,

--- a/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/deserialization/GroupByArgumentDeserializationConfig.java
+++ b/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/deserialization/GroupByArgumentDeserializationConfig.java
@@ -33,9 +33,6 @@ public class GroupByArgumentDeserializationConfig implements ArgumentDeserializa
   @Accessors(fluent = true)
   @NoArgsConstructor(force = true)
   private static class DefaultGroupByArgument implements GroupByArgument {
-    @JsonProperty(GROUP_BY_KEY_KEY)
-    String key;
-
     @JsonProperty(GROUP_BY_KEYS_KEY)
     List<String> keys;
 

--- a/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/request/DefaultExploreRequestBuilder.java
+++ b/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/request/DefaultExploreRequestBuilder.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.inject.Inject;
 import lombok.Value;
 import lombok.experimental.Accessors;
@@ -122,7 +121,8 @@ class DefaultExploreRequestBuilder implements ExploreRequestBuilder {
     Optional<String> spaceId =
         this.argumentDeserializer.deserializePrimitive(arguments, SpaceArgument.class);
 
-    Set<String> groupByKeys = groupBy.map(this::collectGroupByKeys).orElse(emptySet());
+    Set<String> groupByKeys =
+        groupBy.map(GroupByArgument::keys).map(Set::copyOf).orElse(emptySet());
 
     Optional<IntervalArgument> intervalArgument =
         this.argumentDeserializer.deserializeObject(arguments, IntervalArgument.class);
@@ -170,14 +170,6 @@ class DefaultExploreRequestBuilder implements ExploreRequestBuilder {
       GraphQlRequestContext context, String explorerScope, Set<String> groupByKeys) {
     return Observable.fromIterable(groupByKeys)
         .flatMapSingle(key -> this.attributeRequestBuilder.buildForKey(context, explorerScope, key))
-        .collect(Collectors.toUnmodifiableSet());
-  }
-
-  // Temporary
-  private Set<String> collectGroupByKeys(GroupByArgument groupBy) {
-    return Stream.concat(
-            Optional.ofNullable(groupBy.keys()).orElse(emptyList()).stream(),
-            Optional.ofNullable(groupBy.key()).stream())
         .collect(Collectors.toUnmodifiableSet());
   }
 

--- a/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/schema/ExploreResult.java
+++ b/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/schema/ExploreResult.java
@@ -1,7 +1,6 @@
 package org.hypertrace.graphql.explorer.schema;
 
 import graphql.annotations.annotationTypes.GraphQLDataFetcher;
-import graphql.annotations.annotationTypes.GraphQLDeprecate;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLNonNull;
@@ -19,7 +18,6 @@ import org.hypertrace.graphql.explorer.schema.argument.SelectionUnitArgument;
 public interface ExploreResult {
 
   String EXPLORE_RESULT_SELECTION_KEY = "selection";
-  String EXPLORE_RESULT_GROUP_NAME_KEY = "groupName";
   String EXPLORE_RESULT_INTERVAL_START_KEY = "intervalStart";
 
   @GraphQLField
@@ -34,12 +32,6 @@ public interface ExploreResult {
       @GraphQLName(SelectionUnitArgument.ARGUMENT_NAME) TimeUnit units) {
     return null;
   }
-
-  @GraphQLField
-  @GraphQLDeprecate
-  @Deprecated
-  @GraphQLName(EXPLORE_RESULT_GROUP_NAME_KEY)
-  String groupName();
 
   @GraphQLField
   @GraphQLName(EXPLORE_RESULT_INTERVAL_START_KEY)

--- a/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/schema/ExplorerSchema.java
+++ b/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/schema/ExplorerSchema.java
@@ -1,6 +1,7 @@
 package org.hypertrace.graphql.explorer.schema;
 
 import graphql.annotations.annotationTypes.GraphQLDataFetcher;
+import graphql.annotations.annotationTypes.GraphQLDeprecate;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLNonNull;
@@ -28,7 +29,7 @@ public interface ExplorerSchema {
   @GraphQLName(EXPLORE_QUERY_NAME)
   @GraphQLDataFetcher(ExplorerFetcher.class)
   ExploreResultSet explore(
-      @GraphQLName(ExplorerContextArgument.ARGUMENT_NAME) ExplorerContext context,
+      @Deprecated @GraphQLName(ExplorerContextArgument.ARGUMENT_NAME) ExplorerContext context,
       @GraphQLName(ExplorerScopeArgument.ARGUMENT_NAME) String scope,
       @GraphQLName(TimeRangeArgument.ARGUMENT_NAME) @GraphQLNonNull TimeRangeArgument timeRange,
       @GraphQLName(SpaceArgument.ARGUMENT_NAME) String space,

--- a/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/schema/argument/GroupByArgument.java
+++ b/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/schema/argument/GroupByArgument.java
@@ -1,30 +1,21 @@
 package org.hypertrace.graphql.explorer.schema.argument;
 
-import graphql.annotations.annotationTypes.GraphQLDeprecate;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
+import graphql.annotations.annotationTypes.GraphQLNonNull;
 import java.util.List;
-import javax.annotation.Nullable;
 
 @GraphQLName(GroupByArgument.TYPE_NAME)
 public interface GroupByArgument {
   String TYPE_NAME = "GroupByArgument";
   String ARGUMENT_NAME = "groupBy";
 
-  @Deprecated String GROUP_BY_KEY_KEY = "key";
   String GROUP_BY_KEYS_KEY = "keys";
   String GROUP_BY_INCLUDE_REST_KEY = "includeRest";
 
   @GraphQLField
-  @GraphQLDeprecate
-  @Deprecated
-  @GraphQLName(GROUP_BY_KEY_KEY)
-  @Nullable
-  String key();
-
-  @GraphQLField // TODO require once key is removed
+  @GraphQLNonNull
   @GraphQLName(GROUP_BY_KEYS_KEY)
-  @Nullable
   List<String> keys();
 
   @GraphQLField


### PR DESCRIPTION
## Description
Remove previously deprecated code that is no longer in use via the UI (and hasn't been for at least 2 months). Deprecate more code (alternatives have been added, but UI has not yet been updated). This is the second part of https://github.com/hypertrace/hypertrace-core-graphql/pull/45 , and depends on that PR.

### Testing
Verified unit tests, UI code, ran HT e2e with change and verified no issues.

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
