### PR TITLE
Space rules update and delete

### DIFF
--- a/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/dao/ConfigServiceSpacesConfigDao.java
+++ b/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/dao/ConfigServiceSpacesConfigDao.java
@@ -10,6 +10,8 @@ import org.hypertrace.core.graphql.utils.grpc.GraphQlGrpcContextBuilder;
 import org.hypertrace.core.graphql.utils.grpc.GrpcChannelRegistry;
 import org.hypertrace.graphql.config.HypertraceGraphQlServiceConfig;
 import org.hypertrace.graphql.spaces.request.SpaceConfigRuleCreationRequest;
+import org.hypertrace.graphql.spaces.request.SpaceConfigRuleDeleteRequest;
+import org.hypertrace.graphql.spaces.request.SpaceConfigRuleUpdateRequest;
 import org.hypertrace.graphql.spaces.schema.query.SpaceConfigRuleResultSet;
 import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRule;
 import org.hypertrace.spaces.config.service.v1.SpacesConfigServiceGrpc;
@@ -66,5 +68,31 @@ class ConfigServiceSpacesConfigDao implements SpacesConfigDao {
                             .withDeadlineAfter(DEFAULT_DEADLINE_SEC, SECONDS)
                             .createRule(this.requestConverter.convertCreationRequest(request))))
         .flatMap(this.responseConverter::convertRule);
+  }
+
+  @Override
+  public Single<SpaceConfigRule> updateRule(SpaceConfigRuleUpdateRequest request) {
+    return Single.fromFuture(
+            this.grpcContextBuilder
+                .build(request.context())
+                .callInContext(
+                    () ->
+                        this.spaceConfigServiceStub
+                            .withDeadlineAfter(DEFAULT_DEADLINE_SEC, SECONDS)
+                            .updateRule(this.requestConverter.convertUpdateRequest(request))))
+        .flatMap(this.responseConverter::convertRule);
+  }
+
+  @Override
+  public Single<Boolean> deleteRule(SpaceConfigRuleDeleteRequest request) {
+    return Single.fromFuture(
+            this.grpcContextBuilder
+                .build(request.context())
+                .callInContext(
+                    () ->
+                        this.spaceConfigServiceStub
+                            .withDeadlineAfter(DEFAULT_DEADLINE_SEC, SECONDS)
+                            .deleteRule(this.requestConverter.convertDeleteRequest(request))))
+        .flatMap(unusedResponse -> this.responseConverter.buildDeleteResponse());
   }
 }

--- a/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/dao/SpaceConfigRulesRequestConverter.java
+++ b/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/dao/SpaceConfigRulesRequestConverter.java
@@ -1,11 +1,16 @@
 package org.hypertrace.graphql.spaces.dao;
 
 import org.hypertrace.graphql.spaces.request.SpaceConfigRuleCreationRequest;
+import org.hypertrace.graphql.spaces.request.SpaceConfigRuleDeleteRequest;
+import org.hypertrace.graphql.spaces.request.SpaceConfigRuleUpdateRequest;
 import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRuleAttributeValueRule;
 import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRuleDefinition;
 import org.hypertrace.spaces.config.service.v1.AttributeValueRuleData;
 import org.hypertrace.spaces.config.service.v1.CreateRuleRequest;
+import org.hypertrace.spaces.config.service.v1.DeleteRuleRequest;
 import org.hypertrace.spaces.config.service.v1.GetRulesRequest;
+import org.hypertrace.spaces.config.service.v1.SpaceConfigRule;
+import org.hypertrace.spaces.config.service.v1.UpdateRuleRequest;
 
 class SpaceConfigRulesRequestConverter {
 
@@ -15,6 +20,16 @@ class SpaceConfigRulesRequestConverter {
 
   GetRulesRequest convertGetRequest() {
     return GetRulesRequest.getDefaultInstance();
+  }
+
+  DeleteRuleRequest convertDeleteRequest(SpaceConfigRuleDeleteRequest deleteRequest) {
+    return DeleteRuleRequest.newBuilder().setId(deleteRequest.id()).build();
+  }
+
+  UpdateRuleRequest convertUpdateRequest(SpaceConfigRuleUpdateRequest updateRequest) {
+    return UpdateRuleRequest.newBuilder()
+        .setUpdatedRule(this.convertRule(updateRequest.rule()))
+        .build();
   }
 
   private CreateRuleRequest buildCreationRequestForRule(SpaceConfigRuleDefinition ruleDefinition) {
@@ -27,6 +42,20 @@ class SpaceConfigRulesRequestConverter {
       default:
         throw new UnsupportedOperationException(
             "Cannot create unknown rule definition type: " + ruleDefinition.type().name());
+    }
+  }
+
+  private SpaceConfigRule convertRule(
+      org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRule rule) {
+    switch (rule.type()) {
+      case ATTRIBUTE_VALUE:
+        return SpaceConfigRule.newBuilder()
+            .setId(rule.id())
+            .setAttributeValueRuleData(this.buildAttributeValueRuleData(rule.attributeValueRule()))
+            .build();
+      default:
+        throw new UnsupportedOperationException(
+            "Cannot convert unknown rule type: " + rule.type().name());
     }
   }
 

--- a/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/dao/SpaceConfigRulesResponseConverter.java
+++ b/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/dao/SpaceConfigRulesResponseConverter.java
@@ -16,6 +16,7 @@ import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRuleType;
 import org.hypertrace.spaces.config.service.v1.AttributeValueRuleData;
 import org.hypertrace.spaces.config.service.v1.CreateRuleResponse;
 import org.hypertrace.spaces.config.service.v1.GetRulesResponse;
+import org.hypertrace.spaces.config.service.v1.UpdateRuleResponse;
 
 @Slf4j
 class SpaceConfigRulesResponseConverter {
@@ -38,6 +39,16 @@ class SpaceConfigRulesResponseConverter {
     return this.convertRule(createRuleResponse.getRule())
         .switchIfEmpty(
             Single.error(new IllegalArgumentException("Unable to convert rule creation response")));
+  }
+
+  Single<Boolean> buildDeleteResponse() {
+    return Single.just(true);
+  }
+
+  Single<SpaceConfigRule> convertRule(UpdateRuleResponse updateRuleResponse) {
+    return this.convertRule(updateRuleResponse.getRule())
+        .switchIfEmpty(
+            Single.error(new IllegalArgumentException("Unable to convert rule update response")));
   }
 
   private Maybe<SpaceConfigRule> convertRule(

--- a/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/dao/SpacesConfigDao.java
+++ b/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/dao/SpacesConfigDao.java
@@ -3,6 +3,8 @@ package org.hypertrace.graphql.spaces.dao;
 import io.reactivex.rxjava3.core.Single;
 import org.hypertrace.core.graphql.context.GraphQlRequestContext;
 import org.hypertrace.graphql.spaces.request.SpaceConfigRuleCreationRequest;
+import org.hypertrace.graphql.spaces.request.SpaceConfigRuleDeleteRequest;
+import org.hypertrace.graphql.spaces.request.SpaceConfigRuleUpdateRequest;
 import org.hypertrace.graphql.spaces.schema.query.SpaceConfigRuleResultSet;
 import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRule;
 
@@ -10,4 +12,8 @@ public interface SpacesConfigDao {
   Single<SpaceConfigRuleResultSet> getAllRules(GraphQlRequestContext requestContext);
 
   Single<SpaceConfigRule> createRule(SpaceConfigRuleCreationRequest request);
+
+  Single<SpaceConfigRule> updateRule(SpaceConfigRuleUpdateRequest request);
+
+  Single<Boolean> deleteRule(SpaceConfigRuleDeleteRequest request);
 }

--- a/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/deserialization/SpaceConfigRuleDeserializationConfig.java
+++ b/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/deserialization/SpaceConfigRuleDeserializationConfig.java
@@ -1,0 +1,62 @@
+package org.hypertrace.graphql.spaces.deserialization;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.util.List;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+import lombok.experimental.Accessors;
+import org.hypertrace.core.graphql.deserialization.ArgumentDeserializationConfig;
+import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRule;
+import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRuleAttributeValueRule;
+import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRuleType;
+
+public class SpaceConfigRuleDeserializationConfig implements ArgumentDeserializationConfig {
+
+  @Override
+  public String getArgumentKey() {
+    return SpaceConfigRule.ARGUMENT_NAME;
+  }
+
+  @Override
+  public Class<SpaceConfigRule> getArgumentSchema() {
+    return SpaceConfigRule.class;
+  }
+
+  @Override
+  public List<Module> jacksonModules() {
+    return List.of(
+        new SimpleModule()
+            .addAbstractTypeMapping(SpaceConfigRule.class, SpaceConfigRuleArgument.class)
+            .addAbstractTypeMapping(
+                SpaceConfigRuleAttributeValueRule.class,
+                SpaceConfigRuleAttributeValueRuleArgument.class));
+  }
+
+  @Value
+  @Accessors(fluent = true)
+  @NoArgsConstructor(force = true)
+  private static class SpaceConfigRuleArgument implements SpaceConfigRule {
+    @JsonProperty(IDENTITY_FIELD_NAME)
+    String id;
+
+    @JsonProperty(SPACE_CONFIG_RULE_DEFINITION_TYPE_KEY)
+    SpaceConfigRuleType type;
+
+    @JsonProperty(SPACE_CONFIG_RULE_DEFINITION_ATTRIBUTE_VALUE_RULE_KEY)
+    SpaceConfigRuleAttributeValueRule attributeValueRule;
+  }
+
+  @Value
+  @Accessors(fluent = true)
+  @NoArgsConstructor(force = true)
+  private static class SpaceConfigRuleAttributeValueRuleArgument
+      implements SpaceConfigRuleAttributeValueRule {
+    @JsonProperty(ATTRIBUTE_VALUE_ATTRIBUTE_SCOPE_KEY)
+    String attributeScope;
+
+    @JsonProperty(ATTRIBUTE_VALUE_ATTRIBUTE_KEY_KEY)
+    String attributeKey;
+  }
+}

--- a/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/deserialization/SpaceRuleIdArgument.java
+++ b/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/deserialization/SpaceRuleIdArgument.java
@@ -1,0 +1,7 @@
+package org.hypertrace.graphql.spaces.deserialization;
+
+import org.hypertrace.core.graphql.deserialization.PrimitiveArgument;
+
+public interface SpaceRuleIdArgument extends PrimitiveArgument<String> {
+  String ARGUMENT_NAME = "id";
+}

--- a/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/deserialization/SpacesDeserializationModule.java
+++ b/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/deserialization/SpacesDeserializationModule.java
@@ -13,5 +13,13 @@ public class SpacesDeserializationModule extends AbstractModule {
     deserializationConfigBinder
         .addBinding()
         .to(SpaceConfigRuleDefinitionDeserializationConfig.class);
+
+    deserializationConfigBinder.addBinding().to(SpaceConfigRuleDeserializationConfig.class);
+
+    deserializationConfigBinder
+        .addBinding()
+        .toInstance(
+            ArgumentDeserializationConfig.forPrimitive(
+                SpaceRuleIdArgument.ARGUMENT_NAME, SpaceRuleIdArgument.class));
   }
 }

--- a/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/mutator/SpaceConfigRuleDeleteMutator.java
+++ b/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/mutator/SpaceConfigRuleDeleteMutator.java
@@ -1,0 +1,39 @@
+package org.hypertrace.graphql.spaces.mutator;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletableFuture;
+import javax.inject.Inject;
+import org.hypertrace.core.graphql.common.fetcher.InjectableDataFetcher;
+import org.hypertrace.graphql.spaces.dao.SpacesConfigDao;
+import org.hypertrace.graphql.spaces.request.SpaceConfigRequestBuilder;
+
+public class SpaceConfigRuleDeleteMutator extends InjectableDataFetcher<Boolean> {
+
+  public SpaceConfigRuleDeleteMutator() {
+    super(SpaceConfigRuleDeleteMutatorImpl.class);
+  }
+
+  static final class SpaceConfigRuleDeleteMutatorImpl
+      implements DataFetcher<CompletableFuture<Boolean>> {
+    private final SpacesConfigDao configDao;
+    private final SpaceConfigRequestBuilder requestBuilder;
+
+    @Inject
+    SpaceConfigRuleDeleteMutatorImpl(
+        SpacesConfigDao configDao, SpaceConfigRequestBuilder requestBuilder) {
+      this.configDao = configDao;
+      this.requestBuilder = requestBuilder;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> get(DataFetchingEnvironment environment) {
+      return this.configDao
+          .deleteRule(
+              this.requestBuilder.buildDeleteRequest(
+                  environment.getContext(), environment.getArguments()))
+          .toCompletionStage()
+          .toCompletableFuture();
+    }
+  }
+}

--- a/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/mutator/SpaceConfigRuleUpdateMutator.java
+++ b/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/mutator/SpaceConfigRuleUpdateMutator.java
@@ -1,0 +1,40 @@
+package org.hypertrace.graphql.spaces.mutator;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletableFuture;
+import javax.inject.Inject;
+import org.hypertrace.core.graphql.common.fetcher.InjectableDataFetcher;
+import org.hypertrace.graphql.spaces.dao.SpacesConfigDao;
+import org.hypertrace.graphql.spaces.request.SpaceConfigRequestBuilder;
+import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRule;
+
+public class SpaceConfigRuleUpdateMutator extends InjectableDataFetcher<SpaceConfigRule> {
+
+  public SpaceConfigRuleUpdateMutator() {
+    super(SpaceConfigRuleUpdateMutatorImpl.class);
+  }
+
+  static final class SpaceConfigRuleUpdateMutatorImpl
+      implements DataFetcher<CompletableFuture<SpaceConfigRule>> {
+    private final SpacesConfigDao configDao;
+    private final SpaceConfigRequestBuilder requestBuilder;
+
+    @Inject
+    SpaceConfigRuleUpdateMutatorImpl(
+        SpacesConfigDao configDao, SpaceConfigRequestBuilder requestBuilder) {
+      this.configDao = configDao;
+      this.requestBuilder = requestBuilder;
+    }
+
+    @Override
+    public CompletableFuture<SpaceConfigRule> get(DataFetchingEnvironment environment) {
+      return this.configDao
+          .updateRule(
+              this.requestBuilder.buildUpdateRequest(
+                  environment.getContext(), environment.getArguments()))
+          .toCompletionStage()
+          .toCompletableFuture();
+    }
+  }
+}

--- a/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/request/SpaceConfigRequestBuilder.java
+++ b/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/request/SpaceConfigRequestBuilder.java
@@ -6,4 +6,10 @@ import org.hypertrace.core.graphql.context.GraphQlRequestContext;
 public interface SpaceConfigRequestBuilder {
   SpaceConfigRuleCreationRequest buildCreationRequest(
       GraphQlRequestContext requestContext, Map<String, Object> arguments);
+
+  SpaceConfigRuleUpdateRequest buildUpdateRequest(
+      GraphQlRequestContext requestContext, Map<String, Object> arguments);
+
+  SpaceConfigRuleDeleteRequest buildDeleteRequest(
+      GraphQlRequestContext requestContext, Map<String, Object> arguments);
 }

--- a/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/request/SpaceConfigRequestBuilderImpl.java
+++ b/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/request/SpaceConfigRequestBuilderImpl.java
@@ -44,6 +44,7 @@ class SpaceConfigRequestBuilderImpl implements SpaceConfigRequestBuilder {
         requestContext,
         this.argumentDeserializer
             .deserializeObject(arguments, SpaceConfigRule.class)
+            .map(this::normalizeRule)
             .orElseThrow());
   }
 
@@ -67,6 +68,11 @@ class SpaceConfigRequestBuilderImpl implements SpaceConfigRequestBuilder {
         definition.type(), this.normalizeAttributeValueRule(definition.attributeValueRule()));
   }
 
+  private SpaceConfigRule normalizeRule(SpaceConfigRule rule) {
+    return new NormalizedSpaceConfigRule(
+        rule.id(), rule.type(), this.normalizeAttributeValueRule(rule.attributeValueRule()));
+  }
+
   private SpaceConfigRuleAttributeValueRule normalizeAttributeValueRule(
       SpaceConfigRuleAttributeValueRule attributeValueRule) {
     return new NormalizedSpaceConfigRuleAttributeValueRule(
@@ -80,6 +86,14 @@ class SpaceConfigRequestBuilderImpl implements SpaceConfigRequestBuilder {
       implements SpaceConfigRuleCreationRequest {
     GraphQlRequestContext context;
     SpaceConfigRuleDefinition ruleDefinition;
+  }
+
+  @Value
+  @Accessors(fluent = true)
+  private static class NormalizedSpaceConfigRule implements SpaceConfigRule {
+    String id;
+    SpaceConfigRuleType type;
+    SpaceConfigRuleAttributeValueRule attributeValueRule;
   }
 
   @Value

--- a/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/request/SpaceConfigRequestBuilderImpl.java
+++ b/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/request/SpaceConfigRequestBuilderImpl.java
@@ -7,6 +7,8 @@ import lombok.experimental.Accessors;
 import org.hypertrace.core.graphql.common.utils.attributes.AttributeScopeStringTranslator;
 import org.hypertrace.core.graphql.context.GraphQlRequestContext;
 import org.hypertrace.core.graphql.deserialization.ArgumentDeserializer;
+import org.hypertrace.graphql.spaces.deserialization.SpaceRuleIdArgument;
+import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRule;
 import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRuleAttributeValueRule;
 import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRuleDefinition;
 import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRuleType;
@@ -32,6 +34,26 @@ class SpaceConfigRequestBuilderImpl implements SpaceConfigRequestBuilder {
         this.argumentDeserializer
             .deserializeObject(arguments, SpaceConfigRuleDefinition.class)
             .map(this::normalizeDefinition)
+            .orElseThrow());
+  }
+
+  @Override
+  public SpaceConfigRuleUpdateRequest buildUpdateRequest(
+      GraphQlRequestContext requestContext, Map<String, Object> arguments) {
+    return new SpaceConfigRuleUpdateRequestImpl(
+        requestContext,
+        this.argumentDeserializer
+            .deserializeObject(arguments, SpaceConfigRule.class)
+            .orElseThrow());
+  }
+
+  @Override
+  public SpaceConfigRuleDeleteRequest buildDeleteRequest(
+      GraphQlRequestContext requestContext, Map<String, Object> arguments) {
+    return new SpaceConfigRuleDeleteRequestImpl(
+        requestContext,
+        this.argumentDeserializer
+            .deserializePrimitive(arguments, SpaceRuleIdArgument.class)
             .orElseThrow());
   }
 
@@ -73,5 +95,19 @@ class SpaceConfigRequestBuilderImpl implements SpaceConfigRequestBuilder {
       implements SpaceConfigRuleAttributeValueRule {
     String attributeScope;
     String attributeKey;
+  }
+
+  @Value
+  @Accessors(fluent = true)
+  private static class SpaceConfigRuleDeleteRequestImpl implements SpaceConfigRuleDeleteRequest {
+    GraphQlRequestContext context;
+    String id;
+  }
+
+  @Value
+  @Accessors(fluent = true)
+  private static class SpaceConfigRuleUpdateRequestImpl implements SpaceConfigRuleUpdateRequest {
+    GraphQlRequestContext context;
+    SpaceConfigRule rule;
   }
 }

--- a/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/request/SpaceConfigRuleDeleteRequest.java
+++ b/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/request/SpaceConfigRuleDeleteRequest.java
@@ -1,0 +1,9 @@
+package org.hypertrace.graphql.spaces.request;
+
+import org.hypertrace.core.graphql.context.GraphQlRequestContext;
+
+public interface SpaceConfigRuleDeleteRequest {
+  GraphQlRequestContext context();
+
+  String id();
+}

--- a/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/request/SpaceConfigRuleUpdateRequest.java
+++ b/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/request/SpaceConfigRuleUpdateRequest.java
@@ -1,0 +1,10 @@
+package org.hypertrace.graphql.spaces.request;
+
+import org.hypertrace.core.graphql.context.GraphQlRequestContext;
+import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRule;
+
+public interface SpaceConfigRuleUpdateRequest {
+  GraphQlRequestContext context();
+
+  SpaceConfigRule rule();
+}

--- a/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/schema/mutation/SpacesMutationSchema.java
+++ b/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/schema/mutation/SpacesMutationSchema.java
@@ -4,13 +4,18 @@ import graphql.annotations.annotationTypes.GraphQLDataFetcher;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLNonNull;
+import org.hypertrace.graphql.spaces.deserialization.SpaceRuleIdArgument;
 import org.hypertrace.graphql.spaces.mutator.SpaceConfigRuleCreationMutator;
+import org.hypertrace.graphql.spaces.mutator.SpaceConfigRuleDeleteMutator;
+import org.hypertrace.graphql.spaces.mutator.SpaceConfigRuleUpdateMutator;
 import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRule;
 import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRuleDefinition;
 
 public interface SpacesMutationSchema {
 
   String CREATE_SPACE_CONFIG_RULE_KEY = "createSpaceConfigRule";
+  String UPDATE_SPACE_CONFIG_RULE_KEY = "updateSpaceConfigRule";
+  String DELETE_SPACE_CONFIG_RULE_KEY = "deleteSpaceConfigRule";
 
   @GraphQLField
   @GraphQLNonNull
@@ -19,4 +24,18 @@ public interface SpacesMutationSchema {
   SpaceConfigRule createSpaceConfigRule(
       @GraphQLNonNull @GraphQLName(SpaceConfigRuleDefinition.ARGUMENT_NAME)
           SpaceConfigRuleDefinition definition);
+
+  @GraphQLField
+  @GraphQLNonNull
+  @GraphQLName(UPDATE_SPACE_CONFIG_RULE_KEY)
+  @GraphQLDataFetcher(SpaceConfigRuleUpdateMutator.class)
+  SpaceConfigRule updateSpaceConfigRule(
+      @GraphQLNonNull @GraphQLName(SpaceConfigRule.ARGUMENT_NAME) SpaceConfigRule rule);
+
+  @GraphQLField
+  @GraphQLNonNull
+  @GraphQLName(DELETE_SPACE_CONFIG_RULE_KEY)
+  @GraphQLDataFetcher(SpaceConfigRuleDeleteMutator.class)
+  Boolean deleteSpaceConfigRule(
+      @GraphQLNonNull @GraphQLName(SpaceRuleIdArgument.ARGUMENT_NAME) String id);
 }

--- a/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/schema/shared/SpaceConfigRule.java
+++ b/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/schema/shared/SpaceConfigRule.java
@@ -5,5 +5,6 @@ import org.hypertrace.core.graphql.common.schema.id.Identifiable;
 
 @GraphQLName(SpaceConfigRule.TYPE_NAME)
 public interface SpaceConfigRule extends Identifiable, SpaceConfigRuleDefinition {
+  String ARGUMENT_NAME = "rule";
   String TYPE_NAME = "SpaceConfigRule";
 }

--- a/hypertrace-graphql-spaces-schema/src/test/java/org/hypertrace/graphql/spaces/dao/SpaceConfigRulesRequestConverterTest.java
+++ b/hypertrace-graphql-spaces-schema/src/test/java/org/hypertrace/graphql/spaces/dao/SpaceConfigRulesRequestConverterTest.java
@@ -5,12 +5,17 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.hypertrace.graphql.spaces.request.SpaceConfigRuleCreationRequest;
+import org.hypertrace.graphql.spaces.request.SpaceConfigRuleDeleteRequest;
+import org.hypertrace.graphql.spaces.request.SpaceConfigRuleUpdateRequest;
+import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRule;
 import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRuleAttributeValueRule;
 import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRuleDefinition;
 import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRuleType;
 import org.hypertrace.spaces.config.service.v1.AttributeValueRuleData;
 import org.hypertrace.spaces.config.service.v1.CreateRuleRequest;
+import org.hypertrace.spaces.config.service.v1.DeleteRuleRequest;
 import org.hypertrace.spaces.config.service.v1.GetRulesRequest;
+import org.hypertrace.spaces.config.service.v1.UpdateRuleRequest;
 import org.junit.jupiter.api.Test;
 
 class SpaceConfigRulesRequestConverterTest {
@@ -47,5 +52,44 @@ class SpaceConfigRulesRequestConverterTest {
     GetRulesRequest expectedRequest = GetRulesRequest.newBuilder().build();
 
     assertEquals(expectedRequest, this.converter.convertGetRequest());
+  }
+
+  @Test
+  void convertsUpdateRequest() {
+    SpaceConfigRuleUpdateRequest mockRequest = mock(SpaceConfigRuleUpdateRequest.class);
+    SpaceConfigRule mockRule = mock(SpaceConfigRule.class);
+    SpaceConfigRuleAttributeValueRule mockAttributeValueRule =
+        mock(SpaceConfigRuleAttributeValueRule.class);
+    when(mockAttributeValueRule.attributeKey()).thenReturn("key");
+    when(mockAttributeValueRule.attributeScope()).thenReturn("scope");
+
+    when(mockRule.attributeValueRule()).thenReturn(mockAttributeValueRule);
+    when(mockRule.type()).thenReturn(SpaceConfigRuleType.ATTRIBUTE_VALUE);
+    when(mockRule.id()).thenReturn("rule-id");
+    when(mockRequest.rule()).thenReturn(mockRule);
+
+    UpdateRuleRequest expectedRequest =
+        UpdateRuleRequest.newBuilder()
+            .setUpdatedRule(
+                org.hypertrace.spaces.config.service.v1.SpaceConfigRule.newBuilder()
+                    .setAttributeValueRuleData(
+                        AttributeValueRuleData.newBuilder()
+                            .setAttributeKey("key")
+                            .setAttributeScope("scope")
+                            .buildPartial())
+                    .setId("rule-id"))
+            .build();
+
+    assertEquals(expectedRequest, this.converter.convertUpdateRequest(mockRequest));
+  }
+
+  @Test
+  void convertsDeleteRequest() {
+    SpaceConfigRuleDeleteRequest mockRequest = mock(SpaceConfigRuleDeleteRequest.class);
+    when(mockRequest.id()).thenReturn("delete-rule-id");
+    DeleteRuleRequest expectedRequest =
+        DeleteRuleRequest.newBuilder().setId("delete-rule-id").build();
+
+    assertEquals(expectedRequest, this.converter.convertDeleteRequest(mockRequest));
   }
 }

--- a/hypertrace-graphql-spaces-schema/src/test/java/org/hypertrace/graphql/spaces/dao/SpaceConfigRulesResponseConverterTest.java
+++ b/hypertrace-graphql-spaces-schema/src/test/java/org/hypertrace/graphql/spaces/dao/SpaceConfigRulesResponseConverterTest.java
@@ -10,6 +10,7 @@ import org.hypertrace.spaces.config.service.v1.AttributeValueRuleData;
 import org.hypertrace.spaces.config.service.v1.CreateRuleResponse;
 import org.hypertrace.spaces.config.service.v1.GetRulesResponse;
 import org.hypertrace.spaces.config.service.v1.SpaceConfigRule;
+import org.hypertrace.spaces.config.service.v1.UpdateRuleResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -76,6 +77,28 @@ class SpaceConfigRulesResponseConverterTest {
   void testConvertingCreateResponse() {
     CreateRuleResponse response =
         CreateRuleResponse.newBuilder()
+            .setRule(
+                SpaceConfigRule.newBuilder()
+                    .setId("id-1")
+                    .setAttributeValueRuleData(
+                        AttributeValueRuleData.newBuilder()
+                            .setAttributeScope(INTERNAL_SCOPE)
+                            .setAttributeKey("key-1")))
+            .build();
+
+    org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRule rule =
+        this.converter.convertRule(response).blockingGet();
+
+    assertEquals("id-1", rule.id());
+    assertEquals(SpaceConfigRuleType.ATTRIBUTE_VALUE, rule.type());
+    assertEquals("key-1", rule.attributeValueRule().attributeKey());
+    assertEquals(EXTERNAL_SCOPE, rule.attributeValueRule().attributeScope());
+  }
+
+  @Test
+  void convertsUpdateResponse() {
+    UpdateRuleResponse response =
+        UpdateRuleResponse.newBuilder()
             .setRule(
                 SpaceConfigRule.newBuilder()
                     .setId("id-1")

--- a/hypertrace-graphql-spaces-schema/src/test/java/org/hypertrace/graphql/spaces/deserialization/SpaceConfigRuleDeserializationConfigTest.java
+++ b/hypertrace-graphql-spaces-schema/src/test/java/org/hypertrace/graphql/spaces/deserialization/SpaceConfigRuleDeserializationConfigTest.java
@@ -1,0 +1,65 @@
+package org.hypertrace.graphql.spaces.deserialization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.multibindings.Multibinder;
+import java.util.Map;
+import org.hypertrace.core.graphql.common.schema.id.Identifiable;
+import org.hypertrace.core.graphql.deserialization.ArgumentDeserializationConfig;
+import org.hypertrace.core.graphql.deserialization.ArgumentDeserializer;
+import org.hypertrace.core.graphql.deserialization.GraphQlDeserializationRegistryModule;
+import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRule;
+import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRuleAttributeValueRule;
+import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRuleDefinition;
+import org.hypertrace.graphql.spaces.schema.shared.SpaceConfigRuleType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SpaceConfigRuleDeserializationConfigTest {
+
+  private ArgumentDeserializer argumentDeserializer;
+
+  @BeforeEach
+  void beforeEach() {
+    this.argumentDeserializer =
+        Guice.createInjector(
+                new GraphQlDeserializationRegistryModule(),
+                new AbstractModule() {
+                  @Override
+                  protected void configure() {
+                    Multibinder.newSetBinder(binder(), ArgumentDeserializationConfig.class)
+                        .addBinding()
+                        .to(SpaceConfigRuleDeserializationConfig.class);
+                  }
+                })
+            .getInstance(ArgumentDeserializer.class);
+  }
+
+  @Test
+  void testDeserialization() {
+    Map<String, Object> argMap =
+        Map.of(
+            SpaceConfigRule.ARGUMENT_NAME,
+            Map.of(
+                SpaceConfigRuleDefinition.SPACE_CONFIG_RULE_DEFINITION_TYPE_KEY,
+                "ATTRIBUTE_VALUE",
+                Identifiable.IDENTITY_FIELD_NAME,
+                "rule-id",
+                SpaceConfigRuleDefinition.SPACE_CONFIG_RULE_DEFINITION_ATTRIBUTE_VALUE_RULE_KEY,
+                Map.of(
+                    SpaceConfigRuleAttributeValueRule.ATTRIBUTE_VALUE_ATTRIBUTE_KEY_KEY,
+                    "key",
+                    SpaceConfigRuleAttributeValueRule.ATTRIBUTE_VALUE_ATTRIBUTE_SCOPE_KEY,
+                    "scope")));
+
+    SpaceConfigRule result =
+        this.argumentDeserializer.deserializeObject(argMap, SpaceConfigRule.class).orElseThrow();
+
+    assertEquals("rule-id", result.id());
+    assertEquals(SpaceConfigRuleType.ATTRIBUTE_VALUE, result.type());
+    assertEquals("scope", result.attributeValueRule().attributeScope());
+    assertEquals("key", result.attributeValueRule().attributeKey());
+  }
+}


### PR DESCRIPTION
## Description
This change adds support for updtaing and deleting space config rules in support of hypertrace/hypertrace#142 .

### Testing

This has been verified E2E and unit tests have been added for code with non-trivial logic.
### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
