### PR TITLE
fix: reverse space ordering to be sorted asc

### DIFF
--- a/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/dao/ExplorerBackedSpacesDao.java
+++ b/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/dao/ExplorerBackedSpacesDao.java
@@ -177,7 +177,7 @@ class ExplorerBackedSpacesDao implements SpacesDao {
   @Value
   @Accessors(fluent = true)
   private static class SpaceOrderArgument implements AggregatableOrderArgument {
-    OrderDirection direction = OrderDirection.DESC;
+    OrderDirection direction = OrderDirection.ASC;
     String key = ActiveSpaceExploreRequest.SPACE_IDS_KEY;
     MetricAggregationType aggregation = null;
     Integer size = null;

--- a/hypertrace-graphql-spaces-schema/src/test/java/org/hypertrace/graphql/spaces/dao/ExplorerBackedSpacesDaoTest.java
+++ b/hypertrace-graphql-spaces-schema/src/test/java/org/hypertrace/graphql/spaces/dao/ExplorerBackedSpacesDaoTest.java
@@ -1,5 +1,6 @@
 package org.hypertrace.graphql.spaces.dao;
 
+import static org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderDirection.ASC;
 import static org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderDirection.DESC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -93,7 +94,7 @@ class ExplorerBackedSpacesDaoTest {
                         && request.orderArguments().size() == 1
                         && request.orderArguments().get(0).attribute().equals(this.mockAttribute)
                         && request.orderArguments().get(0).value().key().equals("spaceIds")
-                        && request.orderArguments().get(0).value().direction().equals(DESC)
+                        && request.orderArguments().get(0).value().direction().equals(ASC)
                         && request.filterArguments().isEmpty()
                         && request
                             .groupByAttributeRequests()


### PR DESCRIPTION
## Description
This was misimplemented - the expectation is the list of spaces should be alphabetical i.e. "A" -> "B", which corresponds to ascending ordering.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
