### PR TITLE
perf(entities): set fetch total flag, if requested

### DIFF
--- a/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/dao/GatewayServiceEntityRequestBuilder.java
+++ b/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/dao/GatewayServiceEntityRequestBuilder.java
@@ -89,6 +89,7 @@ class GatewayServiceEntityRequestBuilder {
                 .setFilter(filter)
                 .setIncludeNonLiveEntities(entityRequest.includeInactive())
                 .setSpaceId(resultSetRequest.spaceId().orElse("")) // String proto default value\
+                .setFetchTotal(entityRequest.fetchTotal())
                 .build());
   }
 }

--- a/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/request/DefaultEntityRequestBuilder.java
+++ b/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/request/DefaultEntityRequestBuilder.java
@@ -81,6 +81,13 @@ class DefaultEntityRequestBuilder implements EntityRequestBuilder {
             .deserializePrimitive(arguments, IncludeInactiveArgument.class)
             .orElse(false);
 
+    boolean fetchTotal =
+        this.selectionFinder
+                .findSelections(
+                    selectionSet, SelectionQuery.namedChild(ResultSet.RESULT_SET_TOTAL_NAME))
+                .count()
+            > 0;
+
     return zip(
         this.resultSetRequestBuilder.build(
             context, scope, arguments, selectionSet, AggregatableOrderArgument.class),
@@ -102,7 +109,8 @@ class DefaultEntityRequestBuilder implements EntityRequestBuilder {
                 metricRequestList,
                 incomingEdges,
                 outgoingEdges,
-                includeInactive));
+                includeInactive,
+                fetchTotal));
   }
 
   private Stream<SelectedField> getResultSets(DataFetchingFieldSelectionSet selectionSet) {
@@ -145,5 +153,6 @@ class DefaultEntityRequestBuilder implements EntityRequestBuilder {
     EdgeSetGroupRequest incomingEdgeRequests;
     EdgeSetGroupRequest outgoingEdgeRequests;
     boolean includeInactive;
+    boolean fetchTotal;
   }
 }

--- a/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/request/EntityRequest.java
+++ b/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/request/EntityRequest.java
@@ -18,4 +18,6 @@ public interface EntityRequest {
   EdgeSetGroupRequest outgoingEdgeRequests();
 
   boolean includeInactive();
+
+  boolean fetchTotal();
 }

--- a/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/request/NeighborEntitiesRequestBuilder.java
+++ b/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/request/NeighborEntitiesRequestBuilder.java
@@ -94,9 +94,12 @@ class NeighborEntitiesRequestBuilder {
                 metricRequestList,
                 incomingEdges,
                 outgoingEdges,
-                false)); // entity interactions doesn't support time agnostic nature, and would mean
-    // that the neighbors would have to be live in the requested time range. Supporting time
-    // agnostic interations would mean a change in the way interactions are implemented
+                false,
+                // entity interactions doesn't support time agnostic nature, and would mean
+                // that the neighbors would have to be live in the requested time range.
+                // Supporting time agnostic interations would mean a change in the way interactions
+                // are implemented
+                false));
   }
 
   private Single<ResultSetRequest<AggregatableOrderArgument>> buildResultSetRequest(
@@ -174,5 +177,6 @@ class NeighborEntitiesRequestBuilder {
     EdgeSetGroupRequest incomingEdgeRequests;
     EdgeSetGroupRequest outgoingEdgeRequests;
     boolean includeInactive;
+    boolean fetchTotal;
   }
 }


### PR DESCRIPTION
## Description
Setting `fetchTotal` on EntitiesRequest, only if the `total` has been requested

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules