### PR TITLE
refactor: expose a way of ordering explorer query by interval

### DIFF
--- a/hypertrace-graphql-explorer-schema/build.gradle.kts
+++ b/hypertrace-graphql-explorer-schema/build.gradle.kts
@@ -1,5 +1,7 @@
 plugins {
   `java-library`
+  jacoco
+  id("org.hypertrace.jacoco-report-plugin")
 }
 
 dependencies {
@@ -24,4 +26,11 @@ dependencies {
   implementation("org.hypertrace.core.graphql:hypertrace-core-graphql-deserialization")
   implementation("org.hypertrace.core.graphql:hypertrace-core-graphql-schema-utils")
 
+  testImplementation("org.junit.jupiter:junit-jupiter")
+  testImplementation("org.mockito:mockito-core")
+  testImplementation("org.mockito:mockito-junit-jupiter")
+}
+
+tasks.test {
+  useJUnitPlatform()
 }

--- a/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/dao/GatewayServiceExploreOrderArgumentConverter.java
+++ b/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/dao/GatewayServiceExploreOrderArgumentConverter.java
@@ -1,0 +1,86 @@
+package org.hypertrace.graphql.explorer.dao;
+
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Single;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import org.hypertrace.core.graphql.common.request.AttributeAssociation;
+import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderDirection;
+import org.hypertrace.core.graphql.common.utils.Converter;
+import org.hypertrace.gateway.service.v1.common.ColumnIdentifier;
+import org.hypertrace.gateway.service.v1.common.Expression;
+import org.hypertrace.gateway.service.v1.common.OrderByExpression;
+import org.hypertrace.gateway.service.v1.common.SortOrder;
+import org.hypertrace.gateway.service.v1.explore.ColumnName;
+import org.hypertrace.graphql.explorer.request.ExploreOrderArgument;
+import org.hypertrace.graphql.metric.schema.argument.AggregatableOrderArgument;
+
+@Slf4j
+class GatewayServiceExploreOrderArgumentConverter
+    implements Converter<List<ExploreOrderArgument>, List<OrderByExpression>> {
+
+  private final Converter<
+          List<AttributeAssociation<AggregatableOrderArgument>>, List<OrderByExpression>>
+      attributeOrderConverter;
+  private final Converter<OrderDirection, SortOrder> sortOrderConverter;
+
+  @Inject
+  GatewayServiceExploreOrderArgumentConverter(
+      Converter<List<AttributeAssociation<AggregatableOrderArgument>>, List<OrderByExpression>>
+          attributeOrderConverter,
+      Converter<OrderDirection, SortOrder> sortOrderConverter) {
+    this.attributeOrderConverter = attributeOrderConverter;
+    this.sortOrderConverter = sortOrderConverter;
+  }
+
+  @Override
+  public Single<List<OrderByExpression>> convert(List<ExploreOrderArgument> arguments) {
+    return Observable.fromIterable(arguments)
+        .concatMapMaybe(this::convert)
+        .collect(Collectors.toUnmodifiableList());
+  }
+
+  private Maybe<OrderByExpression> convert(ExploreOrderArgument argument) {
+    switch (argument.type()) {
+      case ATTRIBUTE:
+        return this.buildAttributeOrderExpression(argument);
+      case INTERVAL_START:
+        return this.buildIntervalStartOrderExpression(argument);
+      default:
+        log.error("Unrecognized order argument type: {}", argument);
+        return Maybe.empty();
+    }
+  }
+
+  private Maybe<OrderByExpression> buildAttributeOrderExpression(ExploreOrderArgument argument) {
+    return Maybe.fromOptional(argument.attribute())
+        .doOnComplete(() -> log.error("Attribute order argument missing attribute: {} ", argument))
+        .flatMapSingle(
+            attribute ->
+                this.attributeOrderConverter.convert(
+                    List.of(AttributeAssociation.of(attribute, argument.argument()))))
+        .mapOptional(list -> list.stream().findFirst());
+  }
+
+  private Maybe<OrderByExpression> buildIntervalStartOrderExpression(
+      ExploreOrderArgument argument) {
+    return this.sortOrderConverter
+        .convert(argument.argument().direction())
+        .map(this::buildIntervalStartOrderExpression)
+        .toMaybe();
+  }
+
+  private OrderByExpression buildIntervalStartOrderExpression(SortOrder sortOrder) {
+    return OrderByExpression.newBuilder()
+        .setOrder(sortOrder)
+        .setExpression(
+            Expression.newBuilder()
+                .setColumnIdentifier(
+                    ColumnIdentifier.newBuilder()
+                        .setColumnName(ColumnName.INTERVAL_START_TIME.name())))
+        .build();
+  }
+}

--- a/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/dao/GatewayServiceExploreRequestBuilder.java
+++ b/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/dao/GatewayServiceExploreRequestBuilder.java
@@ -8,7 +8,6 @@ import io.reactivex.rxjava3.core.Single;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -21,19 +20,15 @@ import org.hypertrace.core.graphql.common.schema.time.TimeUnit;
 import org.hypertrace.core.graphql.common.utils.Converter;
 import org.hypertrace.gateway.service.v1.common.Expression;
 import org.hypertrace.gateway.service.v1.common.Filter;
-import org.hypertrace.gateway.service.v1.common.OrderByExpression;
 import org.hypertrace.gateway.service.v1.common.TimeAggregation;
 import org.hypertrace.graphql.explorer.request.ExploreRequest;
 import org.hypertrace.graphql.explorer.schema.argument.IntervalArgument;
 import org.hypertrace.graphql.metric.request.MetricAggregationRequest;
 import org.hypertrace.graphql.metric.request.MetricSeriesRequest;
-import org.hypertrace.graphql.metric.schema.argument.AggregatableOrderArgument;
 
 public class GatewayServiceExploreRequestBuilder {
   private final Converter<Collection<AttributeAssociation<FilterArgument>>, Filter> filterConverter;
-  private final Converter<
-          List<AttributeAssociation<AggregatableOrderArgument>>, List<OrderByExpression>>
-      orderConverter;
+  private final GatewayServiceExploreOrderArgumentConverter orderConverter;
   private final Converter<Collection<AttributeRequest>, Set<Expression>> attributeConverter;
   private final Converter<Collection<MetricAggregationRequest>, Set<Expression>>
       aggregationConverter;
@@ -42,8 +37,7 @@ public class GatewayServiceExploreRequestBuilder {
   @Inject
   GatewayServiceExploreRequestBuilder(
       Converter<Collection<AttributeAssociation<FilterArgument>>, Filter> filterConverter,
-      Converter<List<AttributeAssociation<AggregatableOrderArgument>>, List<OrderByExpression>>
-          orderConverter,
+      GatewayServiceExploreOrderArgumentConverter orderConverter,
       Converter<Collection<AttributeRequest>, Set<Expression>> attributeConverter,
       Converter<Collection<MetricAggregationRequest>, Set<Expression>> aggregationConverter,
       Converter<Collection<MetricSeriesRequest>, Set<TimeAggregation>> seriesConverter) {

--- a/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/request/ExploreOrderArgument.java
+++ b/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/request/ExploreOrderArgument.java
@@ -1,0 +1,19 @@
+package org.hypertrace.graphql.explorer.request;
+
+import java.util.Optional;
+import org.hypertrace.core.graphql.attributes.AttributeModel;
+import org.hypertrace.graphql.metric.schema.argument.AggregatableOrderArgument;
+
+public interface ExploreOrderArgument {
+
+  ExploreOrderArgumentType type();
+
+  AggregatableOrderArgument argument();
+
+  Optional<AttributeModel> attribute();
+
+  enum ExploreOrderArgumentType {
+    ATTRIBUTE,
+    INTERVAL_START
+  }
+}

--- a/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/request/ExploreOrderArgumentBuilder.java
+++ b/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/request/ExploreOrderArgumentBuilder.java
@@ -1,0 +1,73 @@
+package org.hypertrace.graphql.explorer.request;
+
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Single;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import lombok.Value;
+import lombok.experimental.Accessors;
+import org.hypertrace.core.graphql.attributes.AttributeModel;
+import org.hypertrace.core.graphql.attributes.AttributeStore;
+import org.hypertrace.core.graphql.context.GraphQlRequestContext;
+import org.hypertrace.graphql.explorer.schema.ExploreResult;
+import org.hypertrace.graphql.metric.schema.argument.AggregatableOrderArgument;
+
+class ExploreOrderArgumentBuilder {
+
+  private final AttributeStore attributeStore;
+
+  @Inject
+  ExploreOrderArgumentBuilder(AttributeStore attributeStore) {
+    this.attributeStore = attributeStore;
+  }
+
+  Single<List<ExploreOrderArgument>> buildList(
+      GraphQlRequestContext context,
+      String requestScope,
+      List<AggregatableOrderArgument> providedOrders) {
+
+    return Observable.fromIterable(providedOrders)
+        .concatMapSingle(
+            argument -> this.buildExploreOrderArgument(context, requestScope, argument))
+        .collect(Collectors.toUnmodifiableList());
+  }
+
+  private Single<ExploreOrderArgument> buildExploreOrderArgument(
+      GraphQlRequestContext requestContext, String scope, AggregatableOrderArgument argument) {
+
+    if (ExploreResult.EXPLORE_RESULT_INTERVAL_START_KEY.equals(argument.key())) {
+      return this.buildIntervalStartExploreOrderArgument(argument);
+    }
+    return this.buildAttributeExploreOrderArgument(requestContext, scope, argument);
+  }
+
+  private Single<ExploreOrderArgument> buildIntervalStartExploreOrderArgument(
+      AggregatableOrderArgument argument) {
+    return Single.just(new IntervalStartExploreOrderArgument(argument));
+  }
+
+  private Single<ExploreOrderArgument> buildAttributeExploreOrderArgument(
+      GraphQlRequestContext requestContext, String scope, AggregatableOrderArgument argument) {
+    return this.attributeStore
+        .get(requestContext, scope, argument.key())
+        .map(model -> new AttributeExploreOrderArgument(argument, Optional.of(model)));
+  }
+
+  @Value
+  @Accessors(fluent = true)
+  private static class IntervalStartExploreOrderArgument implements ExploreOrderArgument {
+    ExploreOrderArgumentType type = ExploreOrderArgumentType.INTERVAL_START;
+    AggregatableOrderArgument argument;
+    Optional<AttributeModel> attribute = Optional.empty();
+  }
+
+  @Value
+  @Accessors(fluent = true)
+  private static class AttributeExploreOrderArgument implements ExploreOrderArgument {
+    ExploreOrderArgumentType type = ExploreOrderArgumentType.ATTRIBUTE;
+    AggregatableOrderArgument argument;
+    Optional<AttributeModel> attribute;
+  }
+}

--- a/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/request/ExploreRequest.java
+++ b/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/request/ExploreRequest.java
@@ -29,7 +29,7 @@ public interface ExploreRequest {
 
   Optional<IntervalArgument> timeInterval();
 
-  List<AttributeAssociation<AggregatableOrderArgument>> orderArguments();
+  List<ExploreOrderArgument> orderArguments();
 
   List<AttributeAssociation<FilterArgument>> filterArguments();
 

--- a/hypertrace-graphql-explorer-schema/src/test/java/org/hypertrace/graphql/explorer/dao/GatewayServiceExploreOrderArgumentConverterTest.java
+++ b/hypertrace-graphql-explorer-schema/src/test/java/org/hypertrace/graphql/explorer/dao/GatewayServiceExploreOrderArgumentConverterTest.java
@@ -1,0 +1,87 @@
+package org.hypertrace.graphql.explorer.dao;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.reactivex.rxjava3.core.Single;
+import java.util.List;
+import java.util.Optional;
+import org.hypertrace.core.graphql.attributes.AttributeModel;
+import org.hypertrace.core.graphql.common.request.AttributeAssociation;
+import org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderDirection;
+import org.hypertrace.core.graphql.common.utils.Converter;
+import org.hypertrace.gateway.service.v1.common.ColumnIdentifier;
+import org.hypertrace.gateway.service.v1.common.Expression;
+import org.hypertrace.gateway.service.v1.common.OrderByExpression;
+import org.hypertrace.gateway.service.v1.common.SortOrder;
+import org.hypertrace.gateway.service.v1.explore.ColumnName;
+import org.hypertrace.graphql.explorer.request.ExploreOrderArgument;
+import org.hypertrace.graphql.explorer.request.ExploreOrderArgument.ExploreOrderArgumentType;
+import org.hypertrace.graphql.metric.schema.argument.AggregatableOrderArgument;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GatewayServiceExploreOrderArgumentConverterTest {
+
+  GatewayServiceExploreOrderArgumentConverter converter;
+
+  @Mock
+  Converter<List<AttributeAssociation<AggregatableOrderArgument>>, List<OrderByExpression>>
+      mockAttributeOrderConverter;
+
+  @Mock Converter<OrderDirection, SortOrder> mockSortOrderConverter;
+
+  @BeforeEach
+  void beforeEach() {
+    this.converter =
+        new GatewayServiceExploreOrderArgumentConverter(
+            mockAttributeOrderConverter, mockSortOrderConverter);
+  }
+
+  @Test
+  void testConvertArgumentList() {
+    OrderByExpression expectedFirstOrder =
+        OrderByExpression.newBuilder()
+            .setOrder(SortOrder.DESC)
+            .setExpression(
+                Expression.newBuilder()
+                    .setColumnIdentifier(
+                        ColumnIdentifier.newBuilder()
+                            .setColumnName(ColumnName.INTERVAL_START_TIME.name())))
+            .build();
+    OrderByExpression expectedSecondOrder =
+        OrderByExpression.newBuilder()
+            .setOrder(SortOrder.ASC)
+            .setExpression(
+                Expression.newBuilder()
+                    .setColumnIdentifier(ColumnIdentifier.newBuilder().setColumnName("other")))
+            .build();
+    AggregatableOrderArgument firstArg = mock(AggregatableOrderArgument.class);
+    when(firstArg.direction()).thenReturn(OrderDirection.DESC);
+    when(mockSortOrderConverter.convert(OrderDirection.DESC))
+        .thenReturn(Single.just(SortOrder.DESC));
+    ExploreOrderArgument firstExplorerArg = mock(ExploreOrderArgument.class);
+    when(firstExplorerArg.type()).thenReturn(ExploreOrderArgumentType.INTERVAL_START);
+    when(firstExplorerArg.argument()).thenReturn(firstArg);
+
+    AggregatableOrderArgument secondArg = mock(AggregatableOrderArgument.class);
+    AttributeModel secondArgAttribute = mock(AttributeModel.class);
+    ExploreOrderArgument secondExplorerArg = mock(ExploreOrderArgument.class);
+    when(secondExplorerArg.type()).thenReturn(ExploreOrderArgumentType.ATTRIBUTE);
+    when(secondExplorerArg.argument()).thenReturn(secondArg);
+    when(secondExplorerArg.attribute()).thenReturn(Optional.of(secondArgAttribute));
+
+    when(this.mockAttributeOrderConverter.convert(
+            List.of(AttributeAssociation.of(secondArgAttribute, secondArg))))
+        .thenReturn(Single.just(List.of(expectedSecondOrder)));
+
+    assertEquals(
+        List.of(expectedFirstOrder, expectedSecondOrder),
+        this.converter.convert(List.of(firstExplorerArg, secondExplorerArg)).blockingGet());
+  }
+}

--- a/hypertrace-graphql-explorer-schema/src/test/java/org/hypertrace/graphql/explorer/request/ExploreOrderArgumentBuilderTest.java
+++ b/hypertrace-graphql-explorer-schema/src/test/java/org/hypertrace/graphql/explorer/request/ExploreOrderArgumentBuilderTest.java
@@ -1,0 +1,60 @@
+package org.hypertrace.graphql.explorer.request;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.reactivex.rxjava3.core.Single;
+import java.util.List;
+import java.util.Optional;
+import org.hypertrace.core.graphql.attributes.AttributeModel;
+import org.hypertrace.core.graphql.attributes.AttributeStore;
+import org.hypertrace.core.graphql.context.GraphQlRequestContext;
+import org.hypertrace.graphql.explorer.request.ExploreOrderArgument.ExploreOrderArgumentType;
+import org.hypertrace.graphql.explorer.schema.ExploreResult;
+import org.hypertrace.graphql.metric.schema.argument.AggregatableOrderArgument;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ExploreOrderArgumentBuilderTest {
+
+  private static final String MOCK_CONTEXT = "mock_context";
+
+  @Mock AttributeStore mockAttributeStore;
+  @Mock GraphQlRequestContext mockRequestContext;
+
+  private ExploreOrderArgumentBuilder exploreOrderArgumentBuilder;
+
+  @BeforeEach
+  void beforeEach() {
+    this.exploreOrderArgumentBuilder = new ExploreOrderArgumentBuilder(this.mockAttributeStore);
+  }
+
+  @Test
+  void convertsList() {
+    AggregatableOrderArgument firstArg = mock(AggregatableOrderArgument.class);
+    when(firstArg.key()).thenReturn(ExploreResult.EXPLORE_RESULT_INTERVAL_START_KEY);
+    AggregatableOrderArgument secondArg = mock(AggregatableOrderArgument.class);
+    when(secondArg.key()).thenReturn("second");
+    AttributeModel mockAttributeModel = mock(AttributeModel.class);
+    when(mockAttributeStore.get(mockRequestContext, MOCK_CONTEXT, "second"))
+        .thenReturn(Single.just(mockAttributeModel));
+
+    List<ExploreOrderArgument> results =
+        this.exploreOrderArgumentBuilder
+            .buildList(this.mockRequestContext, MOCK_CONTEXT, List.of(firstArg, secondArg))
+            .blockingGet();
+
+    assertEquals(2, results.size());
+    assertEquals(ExploreOrderArgumentType.INTERVAL_START, results.get(0).type());
+    assertEquals(Optional.empty(), results.get(0).attribute());
+    assertEquals(firstArg, results.get(0).argument());
+    assertEquals(ExploreOrderArgumentType.ATTRIBUTE, results.get(1).type());
+    assertEquals(Optional.of(mockAttributeModel), results.get(1).attribute());
+    assertEquals(secondArg, results.get(1).argument());
+  }
+}

--- a/hypertrace-graphql-spaces-schema/src/test/java/org/hypertrace/graphql/spaces/dao/ExplorerBackedSpacesDaoTest.java
+++ b/hypertrace-graphql-spaces-schema/src/test/java/org/hypertrace/graphql/spaces/dao/ExplorerBackedSpacesDaoTest.java
@@ -1,7 +1,6 @@
 package org.hypertrace.graphql.spaces.dao;
 
 import static org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderDirection.ASC;
-import static org.hypertrace.core.graphql.common.schema.results.arguments.order.OrderDirection.DESC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -15,6 +14,7 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.hypertrace.core.graphql.attributes.AttributeModel;
@@ -92,9 +92,9 @@ class ExplorerBackedSpacesDaoTest {
                         && request.attributeRequests().isEmpty()
                         && request.aggregationRequests().equals(Set.of(this.mockSpaceCountRequest))
                         && request.orderArguments().size() == 1
-                        && request.orderArguments().get(0).attribute().equals(this.mockAttribute)
-                        && request.orderArguments().get(0).value().key().equals("spaceIds")
-                        && request.orderArguments().get(0).value().direction().equals(ASC)
+                        && request.orderArguments().get(0).attribute().equals(Optional.of(this.mockAttribute))
+                        && request.orderArguments().get(0).argument().key().equals("spaceIds")
+                        && request.orderArguments().get(0).argument().direction().equals(ASC)
                         && request.filterArguments().isEmpty()
                         && request
                             .groupByAttributeRequests()


### PR DESCRIPTION
## Description
Because the interval field in explorer was first class, the generic ordering argument that accepted a string as key does not support anything beyond the default ordering, which is ascending. Along with https://github.com/hypertrace/gateway-service/pull/82 , this adds support for ordering by interval by passing the name of the interval field `intervalStart` without otherwise changing the api.

### Testing
Added UT. Will test e2e before merging

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

