### PR TITLE
fix: work around time agnostic query issue

### DIFF
--- a/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/joiner/DefaultEntityJoinerBuilder.java
+++ b/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/joiner/DefaultEntityJoinerBuilder.java
@@ -281,8 +281,8 @@ class DefaultEntityJoinerBuilder implements EntityJoinerBuilder {
   @Value
   @Accessors(fluent = true)
   private static class InstantTimeRange implements TimeRangeArgument {
-    // Modify start time just because gateway requires it to be before endtime
-    Instant startTime = Instant.now().minus(1, ChronoUnit.MINUTES);
+    // Bug in gateway requires this time range be larger, even though we don't care about it
+    Instant startTime = Instant.now().minus(15, ChronoUnit.MINUTES);
     Instant endTime = Instant.now();
   }
 


### PR DESCRIPTION
## Description
Recently, gateway service stopped returning results for recent time ranges, even when includeActive is true. This extends the time range on the entity join even though we don't use the time range until the gateway issue can be addressed.

### Testing
Verified E2E

