### PR TITLE
Gateway-Service Client Timeout Config

### DIFF
--- a/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/dao/GatewayBaselineDao.java
+++ b/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/dao/GatewayBaselineDao.java
@@ -1,7 +1,7 @@
 package org.hypertrace.graphql.entity.dao;
 
 import static io.reactivex.rxjava3.core.Single.zip;
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hypertrace.core.graphql.common.utils.CollectorUtils.flatten;
 
 import io.grpc.CallCredentials;
@@ -130,7 +130,7 @@ class GatewayBaselineDao implements BaselineDao {
                 () ->
                     this.gatewayServiceStub
                         .withDeadlineAfter(
-                            serviceConfig.getGatewayServiceRPCClientDeadline(), SECONDS)
+                            serviceConfig.getGatewayServiceTimeout().toMillis(), MILLISECONDS)
                         .getBaselineForEntities(request)));
   }
 }

--- a/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/dao/GatewayBaselineDao.java
+++ b/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/dao/GatewayBaselineDao.java
@@ -53,8 +53,8 @@ class GatewayBaselineDao implements BaselineDao {
     this.grpcContextBuilder = grpcContextBuilder;
     this.gatewayServiceStub =
         GatewayServiceGrpc.newFutureStub(
-            grpcChannelRegistry.forAddress(
-                serviceConfig.getGatewayServiceHost(), serviceConfig.getGatewayServicePort()))
+                grpcChannelRegistry.forAddress(
+                    serviceConfig.getGatewayServiceHost(), serviceConfig.getGatewayServicePort()))
             .withCallCredentials(credentials);
     this.seriesConverter = seriesConverter;
     this.aggregationConverter = aggregationConverter;
@@ -129,8 +129,8 @@ class GatewayBaselineDao implements BaselineDao {
             .callInContext(
                 () ->
                     this.gatewayServiceStub
-                        .withDeadlineAfter(serviceConfig.getGatewayServiceRPCClientDeadline(),
-                            SECONDS)
+                        .withDeadlineAfter(
+                            serviceConfig.getGatewayServiceRPCClientDeadline(), SECONDS)
                         .getBaselineForEntities(request)));
   }
 }

--- a/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/dao/GatewayBaselineDao.java
+++ b/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/dao/GatewayBaselineDao.java
@@ -40,6 +40,7 @@ class GatewayBaselineDao implements BaselineDao {
   private final Converter<Collection<MetricAggregationRequest>, Set<Expression>>
       aggregationConverter;
   private final Converter<Collection<MetricSeriesRequest>, Set<TimeAggregation>> seriesConverter;
+  private final GraphQlServiceConfig serviceConfig;
 
   @Inject
   GatewayBaselineDao(
@@ -52,11 +53,12 @@ class GatewayBaselineDao implements BaselineDao {
     this.grpcContextBuilder = grpcContextBuilder;
     this.gatewayServiceStub =
         GatewayServiceGrpc.newFutureStub(
-                grpcChannelRegistry.forAddress(
-                    serviceConfig.getGatewayServiceHost(), serviceConfig.getGatewayServicePort()))
+            grpcChannelRegistry.forAddress(
+                serviceConfig.getGatewayServiceHost(), serviceConfig.getGatewayServicePort()))
             .withCallCredentials(credentials);
     this.seriesConverter = seriesConverter;
     this.aggregationConverter = aggregationConverter;
+    this.serviceConfig = serviceConfig;
   }
 
   @Override
@@ -127,7 +129,8 @@ class GatewayBaselineDao implements BaselineDao {
             .callInContext(
                 () ->
                     this.gatewayServiceStub
-                        .withDeadlineAfter(DEFAULT_DEADLINE_SEC, SECONDS)
+                        .withDeadlineAfter(serviceConfig.getGatewayServiceRPCClientDeadline(),
+                            SECONDS)
                         .getBaselineForEntities(request)));
   }
 }

--- a/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/dao/GatewayServiceEntityDao.java
+++ b/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/dao/GatewayServiceEntityDao.java
@@ -20,12 +20,12 @@ import org.hypertrace.graphql.entity.schema.EntityResultSet;
 
 @Singleton
 class GatewayServiceEntityDao implements EntityDao {
-  private static final int DEFAULT_DEADLINE_SEC = 10;
   private final GatewayServiceFutureStub gatewayServiceStub;
   private final GraphQlGrpcContextBuilder grpcContextBuilder;
   private final GatewayServiceEntityRequestBuilder requestBuilder;
   private final GatewayServiceEntityConverter entityConverter;
   private final BaselineDao baselineDao;
+  private final GraphQlServiceConfig serviceConfig;
 
   @Inject
   GatewayServiceEntityDao(
@@ -40,11 +40,12 @@ class GatewayServiceEntityDao implements EntityDao {
     this.requestBuilder = requestBuilder;
     this.entityConverter = entityConverter;
     this.baselineDao = baselineDao;
+    this.serviceConfig = serviceConfig;
 
     this.gatewayServiceStub =
         GatewayServiceGrpc.newFutureStub(
-                grpcChannelRegistry.forAddress(
-                    serviceConfig.getGatewayServiceHost(), serviceConfig.getGatewayServicePort()))
+            grpcChannelRegistry.forAddress(
+                serviceConfig.getGatewayServiceHost(), serviceConfig.getGatewayServicePort()))
             .withCallCredentials(credentials);
   }
 
@@ -77,7 +78,8 @@ class GatewayServiceEntityDao implements EntityDao {
             .callInContext(
                 () ->
                     this.gatewayServiceStub
-                        .withDeadlineAfter(DEFAULT_DEADLINE_SEC, SECONDS)
+                        .withDeadlineAfter(serviceConfig.getGatewayServiceRPCClientDeadline(),
+                            SECONDS)
                         .getEntities(request)));
   }
 }

--- a/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/dao/GatewayServiceEntityDao.java
+++ b/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/dao/GatewayServiceEntityDao.java
@@ -44,8 +44,8 @@ class GatewayServiceEntityDao implements EntityDao {
 
     this.gatewayServiceStub =
         GatewayServiceGrpc.newFutureStub(
-            grpcChannelRegistry.forAddress(
-                serviceConfig.getGatewayServiceHost(), serviceConfig.getGatewayServicePort()))
+                grpcChannelRegistry.forAddress(
+                    serviceConfig.getGatewayServiceHost(), serviceConfig.getGatewayServicePort()))
             .withCallCredentials(credentials);
   }
 
@@ -78,8 +78,8 @@ class GatewayServiceEntityDao implements EntityDao {
             .callInContext(
                 () ->
                     this.gatewayServiceStub
-                        .withDeadlineAfter(serviceConfig.getGatewayServiceRPCClientDeadline(),
-                            SECONDS)
+                        .withDeadlineAfter(
+                            serviceConfig.getGatewayServiceRPCClientDeadline(), SECONDS)
                         .getEntities(request)));
   }
 }

--- a/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/dao/GatewayServiceEntityDao.java
+++ b/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/dao/GatewayServiceEntityDao.java
@@ -1,6 +1,6 @@
 package org.hypertrace.graphql.entity.dao;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import io.grpc.CallCredentials;
 import io.reactivex.rxjava3.core.Single;
@@ -79,7 +79,7 @@ class GatewayServiceEntityDao implements EntityDao {
                 () ->
                     this.gatewayServiceStub
                         .withDeadlineAfter(
-                            serviceConfig.getGatewayServiceRPCClientDeadline(), SECONDS)
+                            serviceConfig.getGatewayServiceTimeout().toMillis(), MILLISECONDS)
                         .getEntities(request)));
   }
 }

--- a/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/dao/GatewayServiceExplorerDao.java
+++ b/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/dao/GatewayServiceExplorerDao.java
@@ -1,6 +1,6 @@
 package org.hypertrace.graphql.explorer.dao;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import io.grpc.CallCredentials;
 import io.reactivex.rxjava3.core.Single;
@@ -62,7 +62,7 @@ class GatewayServiceExplorerDao implements ExplorerDao {
                 () ->
                     this.gatewayServiceStub
                         .withDeadlineAfter(
-                            serviceConfig.getGatewayServiceRPCClientDeadline(), SECONDS)
+                            serviceConfig.getGatewayServiceTimeout().toMillis(), MILLISECONDS)
                         .explore(request)));
   }
 }

--- a/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/dao/GatewayServiceExplorerDao.java
+++ b/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/dao/GatewayServiceExplorerDao.java
@@ -39,8 +39,8 @@ class GatewayServiceExplorerDao implements ExplorerDao {
 
     this.gatewayServiceStub =
         GatewayServiceGrpc.newFutureStub(
-            grpcChannelRegistry.forAddress(
-                serviceConfig.getGatewayServiceHost(), serviceConfig.getGatewayServicePort()))
+                grpcChannelRegistry.forAddress(
+                    serviceConfig.getGatewayServiceHost(), serviceConfig.getGatewayServicePort()))
             .withCallCredentials(credentials);
   }
 
@@ -61,8 +61,8 @@ class GatewayServiceExplorerDao implements ExplorerDao {
             .callInContext(
                 () ->
                     this.gatewayServiceStub
-                        .withDeadlineAfter(serviceConfig.getGatewayServiceRPCClientDeadline(),
-                            SECONDS)
+                        .withDeadlineAfter(
+                            serviceConfig.getGatewayServiceRPCClientDeadline(), SECONDS)
                         .explore(request)));
   }
 }

--- a/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/dao/GatewayServiceExplorerDao.java
+++ b/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/dao/GatewayServiceExplorerDao.java
@@ -18,11 +18,11 @@ import org.hypertrace.graphql.explorer.schema.ExploreResultSet;
 
 @Singleton
 class GatewayServiceExplorerDao implements ExplorerDao {
-  private static final int DEFAULT_DEADLINE_SEC = 10;
   private final GatewayServiceFutureStub gatewayServiceStub;
   private final GraphQlGrpcContextBuilder grpcContextBuilder;
   private final GatewayServiceExploreRequestBuilder requestBuilder;
   private final GatewayServiceExploreResponseConverter responseConverter;
+  private final GraphQlServiceConfig serviceConfig;
 
   @Inject
   GatewayServiceExplorerDao(
@@ -35,11 +35,12 @@ class GatewayServiceExplorerDao implements ExplorerDao {
     this.grpcContextBuilder = grpcContextBuilder;
     this.requestBuilder = requestBuilder;
     this.responseConverter = responseConverter;
+    this.serviceConfig = serviceConfig;
 
     this.gatewayServiceStub =
         GatewayServiceGrpc.newFutureStub(
-                grpcChannelRegistry.forAddress(
-                    serviceConfig.getGatewayServiceHost(), serviceConfig.getGatewayServicePort()))
+            grpcChannelRegistry.forAddress(
+                serviceConfig.getGatewayServiceHost(), serviceConfig.getGatewayServicePort()))
             .withCallCredentials(credentials);
   }
 
@@ -60,7 +61,8 @@ class GatewayServiceExplorerDao implements ExplorerDao {
             .callInContext(
                 () ->
                     this.gatewayServiceStub
-                        .withDeadlineAfter(DEFAULT_DEADLINE_SEC, SECONDS)
+                        .withDeadlineAfter(serviceConfig.getGatewayServiceRPCClientDeadline(),
+                            SECONDS)
                         .explore(request)));
   }
 }

--- a/hypertrace-graphql-service/src/main/java/org/hypertrace/graphql/service/DefaultGraphQlServiceConfig.java
+++ b/hypertrace-graphql-service/src/main/java/org/hypertrace/graphql/service/DefaultGraphQlServiceConfig.java
@@ -64,7 +64,8 @@ class DefaultGraphQlServiceConfig implements HypertraceGraphQlServiceConfig {
     this.entityServicePort = untypedConfig.getInt(ENTITY_SERVICE_PORT_PROPERTY);
     this.configServiceHost = untypedConfig.getString(CONFIG_SERVICE_HOST_PROPERTY);
     this.configServicePort = untypedConfig.getInt(CONFIG_SERVICE_PORT_PROPERTY);
-    this.gatewayServiceRPCClientDeadline = untypedConfig.getInt(GATEWAY_SERVICE_RPC_CLIENT_DEADLINE);
+    this.gatewayServiceRPCClientDeadline =
+        untypedConfig.getInt(GATEWAY_SERVICE_RPC_CLIENT_DEADLINE);
   }
 
   private <T> Optional<T> optionallyGet(Supplier<T> valueSupplier) {

--- a/hypertrace-graphql-service/src/main/java/org/hypertrace/graphql/service/DefaultGraphQlServiceConfig.java
+++ b/hypertrace-graphql-service/src/main/java/org/hypertrace/graphql/service/DefaultGraphQlServiceConfig.java
@@ -24,6 +24,7 @@ class DefaultGraphQlServiceConfig implements HypertraceGraphQlServiceConfig {
 
   private static final String GATEWAY_SERVICE_HOST_PROPERTY = "gateway.service.host";
   private static final String GATEWAY_SERVICE_PORT_PROPERTY = "gateway.service.port";
+  private static final String GATEWAY_SERVICE_RPC_CLIENT_DEADLINE = "gateway.service.deadline";
 
   private static final String ENTITY_SERVICE_HOST_PROPERTY = "entity.service.host";
   private static final String ENTITY_SERVICE_PORT_PROPERTY = "entity.service.port";
@@ -41,6 +42,7 @@ class DefaultGraphQlServiceConfig implements HypertraceGraphQlServiceConfig {
   int attributeServicePort;
   String gatewayServiceHost;
   int gatewayServicePort;
+  int gatewayServiceRPCClientDeadline;
   String entityServiceHost;
   int entityServicePort;
   String configServiceHost;
@@ -62,6 +64,7 @@ class DefaultGraphQlServiceConfig implements HypertraceGraphQlServiceConfig {
     this.entityServicePort = untypedConfig.getInt(ENTITY_SERVICE_PORT_PROPERTY);
     this.configServiceHost = untypedConfig.getString(CONFIG_SERVICE_HOST_PROPERTY);
     this.configServicePort = untypedConfig.getInt(CONFIG_SERVICE_PORT_PROPERTY);
+    this.gatewayServiceRPCClientDeadline = untypedConfig.getInt(GATEWAY_SERVICE_RPC_CLIENT_DEADLINE);
   }
 
   private <T> Optional<T> optionallyGet(Supplier<T> valueSupplier) {

--- a/hypertrace-graphql-service/src/main/java/org/hypertrace/graphql/service/DefaultGraphQlServiceConfig.java
+++ b/hypertrace-graphql-service/src/main/java/org/hypertrace/graphql/service/DefaultGraphQlServiceConfig.java
@@ -1,6 +1,7 @@
 package org.hypertrace.graphql.service;
 
 import com.typesafe.config.Config;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Supplier;
 import lombok.Value;
@@ -24,7 +25,7 @@ class DefaultGraphQlServiceConfig implements HypertraceGraphQlServiceConfig {
 
   private static final String GATEWAY_SERVICE_HOST_PROPERTY = "gateway.service.host";
   private static final String GATEWAY_SERVICE_PORT_PROPERTY = "gateway.service.port";
-  private static final String GATEWAY_SERVICE_RPC_CLIENT_DEADLINE = "gateway.service.deadline";
+  private static final String GATEWAY_SERVICE_CLIENT_TIMEOUT = "gateway.service.timeout";
 
   private static final String ENTITY_SERVICE_HOST_PROPERTY = "entity.service.host";
   private static final String ENTITY_SERVICE_PORT_PROPERTY = "entity.service.port";
@@ -42,7 +43,7 @@ class DefaultGraphQlServiceConfig implements HypertraceGraphQlServiceConfig {
   int attributeServicePort;
   String gatewayServiceHost;
   int gatewayServicePort;
-  int gatewayServiceRPCClientDeadline;
+  Duration gatewayServiceTimeout;
   String entityServiceHost;
   int entityServicePort;
   String configServiceHost;
@@ -64,8 +65,11 @@ class DefaultGraphQlServiceConfig implements HypertraceGraphQlServiceConfig {
     this.entityServicePort = untypedConfig.getInt(ENTITY_SERVICE_PORT_PROPERTY);
     this.configServiceHost = untypedConfig.getString(CONFIG_SERVICE_HOST_PROPERTY);
     this.configServicePort = untypedConfig.getInt(CONFIG_SERVICE_PORT_PROPERTY);
-    this.gatewayServiceRPCClientDeadline =
-        untypedConfig.getInt(GATEWAY_SERVICE_RPC_CLIENT_DEADLINE);
+    // fallback timeout: 10s
+    this.gatewayServiceTimeout =
+        untypedConfig.hasPath(GATEWAY_SERVICE_CLIENT_TIMEOUT)
+            ? untypedConfig.getDuration(GATEWAY_SERVICE_CLIENT_TIMEOUT)
+            : Duration.ofSeconds(10);
   }
 
   private <T> Optional<T> optionallyGet(Supplier<T> valueSupplier) {


### PR DESCRIPTION
## Description
These changes are in context of: hypertrace/hypertrace-core-graphql#69. Currently, we hardcode the deadline as 10s. Now, GATEWAY_SERVICE_DEADLINE is read from application.conf


### Testing
Deployed and tested the application manually. I am still seeing if I can write a UT for check if config value is being loaded properly. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

This PR is dependent on: https://github.com/hypertrace/hypertrace-service/pull/99

