### PR TITLE
Entity Service and Config Service Configurable Timeouts

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,6 +5,6 @@ ignore:
   SNYK-JAVA-IONETTY-1042268:
     - '*':
         reason: No replacement available
-        expires: 2021-06-30T00:00:00.000Z
+        expires: 2021-09-01T00:00:00.000Z
 patch: {}
 

--- a/hypertrace-graphql-service-config/src/main/java/org/hypertrace/graphql/config/HypertraceGraphQlServiceConfig.java
+++ b/hypertrace-graphql-service-config/src/main/java/org/hypertrace/graphql/config/HypertraceGraphQlServiceConfig.java
@@ -1,5 +1,6 @@
 package org.hypertrace.graphql.config;
 
+import java.time.Duration;
 import org.hypertrace.core.graphql.spi.config.GraphQlServiceConfig;
 
 public interface HypertraceGraphQlServiceConfig extends GraphQlServiceConfig {
@@ -7,7 +8,11 @@ public interface HypertraceGraphQlServiceConfig extends GraphQlServiceConfig {
 
   int getEntityServicePort();
 
+  Duration getEntityServiceTimeout();
+
   String getConfigServiceHost();
 
   int getConfigServicePort();
+
+  Duration getConfigServiceTimeout();
 }

--- a/hypertrace-graphql-service/src/main/java/org/hypertrace/graphql/service/DefaultGraphQlServiceConfig.java
+++ b/hypertrace-graphql-service/src/main/java/org/hypertrace/graphql/service/DefaultGraphQlServiceConfig.java
@@ -89,11 +89,8 @@ class DefaultGraphQlServiceConfig implements HypertraceGraphQlServiceConfig {
   }
 
   private Duration getSuppliedDurationOrFallback(Supplier<Duration> durationSupplier) {
-    try {
-      return durationSupplier.get();
-    } catch (Throwable unused) {
-      return Duration.ofSeconds(DEFAULT_CLIENT_TIMEOUT_SECONDS);
-    }
+    return optionallyGet(durationSupplier)
+        .orElse(Duration.ofSeconds(DEFAULT_CLIENT_TIMEOUT_SECONDS));
   }
 
   private <T> Optional<T> optionallyGet(Supplier<T> valueSupplier) {

--- a/hypertrace-graphql-service/src/main/java/org/hypertrace/graphql/service/DefaultGraphQlServiceConfig.java
+++ b/hypertrace-graphql-service/src/main/java/org/hypertrace/graphql/service/DefaultGraphQlServiceConfig.java
@@ -24,7 +24,7 @@ class DefaultGraphQlServiceConfig implements HypertraceGraphQlServiceConfig {
 
   private static final String ATTRIBUTE_SERVICE_HOST_PROPERTY = "attribute.service.host";
   private static final String ATTRIBUTE_SERVICE_PORT_PROPERTY = "attribute.service.port";
-  private static final String ATTRIBUTE_SERVICE_PORT_TIMEOUT = "attribute.service.timeout";
+  private static final String ATTRIBUTE_SERVICE_CLIENT_TIMEOUT = "attribute.service.timeout";
 
   private static final String GATEWAY_SERVICE_HOST_PROPERTY = "gateway.service.host";
   private static final String GATEWAY_SERVICE_PORT_PROPERTY = "gateway.service.port";
@@ -79,7 +79,7 @@ class DefaultGraphQlServiceConfig implements HypertraceGraphQlServiceConfig {
             () -> untypedConfig.getDuration(GATEWAY_SERVICE_CLIENT_TIMEOUT));
     this.attributeServiceTimeout =
         getSuppliedDurationOrFallback(
-            () -> untypedConfig.getDuration(ATTRIBUTE_SERVICE_PORT_TIMEOUT));
+            () -> untypedConfig.getDuration(ATTRIBUTE_SERVICE_CLIENT_TIMEOUT));
     this.configServiceTimeout =
         getSuppliedDurationOrFallback(
             () -> untypedConfig.getDuration(CONFIG_SERVICE_CLIENT_TIMEOUT));

--- a/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/dao/ConfigServiceSpacesConfigDao.java
+++ b/hypertrace-graphql-spaces-schema/src/main/java/org/hypertrace/graphql/spaces/dao/ConfigServiceSpacesConfigDao.java
@@ -1,9 +1,8 @@
 package org.hypertrace.graphql.spaces.dao;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-
 import io.grpc.CallCredentials;
 import io.reactivex.rxjava3.core.Single;
+import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import org.hypertrace.core.graphql.context.GraphQlRequestContext;
 import org.hypertrace.core.graphql.utils.grpc.GraphQlGrpcContextBuilder;
@@ -19,11 +18,11 @@ import org.hypertrace.spaces.config.service.v1.SpacesConfigServiceGrpc.SpacesCon
 
 class ConfigServiceSpacesConfigDao implements SpacesConfigDao {
 
-  private static final int DEFAULT_DEADLINE_SEC = 10;
   private final SpacesConfigServiceFutureStub spaceConfigServiceStub;
   private final GraphQlGrpcContextBuilder grpcContextBuilder;
   private final SpaceConfigRulesRequestConverter requestConverter;
   private final SpaceConfigRulesResponseConverter responseConverter;
+  private final HypertraceGraphQlServiceConfig serviceConfig;
 
   @Inject
   ConfigServiceSpacesConfigDao(
@@ -36,6 +35,7 @@ class ConfigServiceSpacesConfigDao implements SpacesConfigDao {
     this.grpcContextBuilder = grpcContextBuilder;
     this.requestConverter = requestConverter;
     this.responseConverter = responseConverter;
+    this.serviceConfig = serviceConfig;
 
     this.spaceConfigServiceStub =
         SpacesConfigServiceGrpc.newFutureStub(
@@ -52,7 +52,9 @@ class ConfigServiceSpacesConfigDao implements SpacesConfigDao {
                 .callInContext(
                     () ->
                         this.spaceConfigServiceStub
-                            .withDeadlineAfter(DEFAULT_DEADLINE_SEC, SECONDS)
+                            .withDeadlineAfter(
+                                serviceConfig.getConfigServiceTimeout().toMillis(),
+                                TimeUnit.MILLISECONDS)
                             .getRules(this.requestConverter.convertGetRequest())))
         .flatMap(this.responseConverter::convertGetResponse);
   }
@@ -65,7 +67,9 @@ class ConfigServiceSpacesConfigDao implements SpacesConfigDao {
                 .callInContext(
                     () ->
                         this.spaceConfigServiceStub
-                            .withDeadlineAfter(DEFAULT_DEADLINE_SEC, SECONDS)
+                            .withDeadlineAfter(
+                                serviceConfig.getConfigServiceTimeout().toMillis(),
+                                TimeUnit.MILLISECONDS)
                             .createRule(this.requestConverter.convertCreationRequest(request))))
         .flatMap(this.responseConverter::convertRule);
   }
@@ -78,7 +82,9 @@ class ConfigServiceSpacesConfigDao implements SpacesConfigDao {
                 .callInContext(
                     () ->
                         this.spaceConfigServiceStub
-                            .withDeadlineAfter(DEFAULT_DEADLINE_SEC, SECONDS)
+                            .withDeadlineAfter(
+                                serviceConfig.getConfigServiceTimeout().toMillis(),
+                                TimeUnit.MILLISECONDS)
                             .updateRule(this.requestConverter.convertUpdateRequest(request))))
         .flatMap(this.responseConverter::convertRule);
   }
@@ -91,7 +97,9 @@ class ConfigServiceSpacesConfigDao implements SpacesConfigDao {
                 .callInContext(
                     () ->
                         this.spaceConfigServiceStub
-                            .withDeadlineAfter(DEFAULT_DEADLINE_SEC, SECONDS)
+                            .withDeadlineAfter(
+                                serviceConfig.getConfigServiceTimeout().toMillis(),
+                                TimeUnit.MILLISECONDS)
                             .deleteRule(this.requestConverter.convertDeleteRequest(request))))
         .flatMap(unusedResponse -> this.responseConverter.buildDeleteResponse());
   }


### PR DESCRIPTION
## Description
Like the PR [here](https://github.com/hypertrace/hypertrace-graphql/pull/91/files), this change is to make client timeout for the Attribute Service configurable.

### Testing
Deployed and tested the application locally. Scenarios:

1. Missing config: Default timeout is used.
2. Timeout configured: Configured value is used.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules