### PR TITLE
ENG-11241: Changes to fetch labels as part of entity joiner

### DIFF
--- a/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/dao/GatewayServiceEntityDao.java
+++ b/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/dao/GatewayServiceEntityDao.java
@@ -6,6 +6,7 @@ import io.grpc.CallCredentials;
 import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.rxjava3.core.Single;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -120,15 +121,17 @@ class GatewayServiceEntityDao implements EntityDao {
   }
 
   private LabelJoiner.LabelIdGetter<Entity> getEntityLabelsGetter(EntityRequest request) {
-    return entity -> {
-      Value labelAttributeValue =
-          entity.getAttributeOrDefault(
-              request.labelRequest().get().labelIdArrayAttributeRequest().attribute().id(), null);
-      if (labelAttributeValue == null) {
-        log.warn("Unable to fetch labels attribute for entity with id {}", entity.getId());
-        return Single.just(Collections.emptyList());
-      }
-      return Single.just(labelAttributeValue.getStringArrayList());
-    };
+    return entity -> Single.just(getLabelAttributeValue(request, entity));
+  }
+
+  private List<String> getLabelAttributeValue(EntityRequest request, Entity entity) {
+    Value labelAttributeValue =
+        entity.getAttributeOrDefault(
+            request.labelRequest().get().labelIdArrayAttributeRequest().attribute().id(), null);
+    if (labelAttributeValue == null) {
+      log.warn("Unable to fetch labels attribute for entity with id {}", entity.getId());
+      return Collections.emptyList();
+    }
+    return labelAttributeValue.getStringArrayList();
   }
 }

--- a/hypertrace-graphql-entity-schema/src/test/java/org/hypertrace/graphql/entity/joiner/DefaultEntityJoinerBuilderTest.java
+++ b/hypertrace-graphql-entity-schema/src/test/java/org/hypertrace/graphql/entity/joiner/DefaultEntityJoinerBuilderTest.java
@@ -4,6 +4,7 @@ import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -25,6 +26,8 @@ import java.util.stream.Stream;
 import lombok.Value;
 import lombok.experimental.Accessors;
 import org.hypertrace.core.graphql.common.request.AttributeAssociation;
+import org.hypertrace.core.graphql.common.request.AttributeRequest;
+import org.hypertrace.core.graphql.common.request.AttributeRequestBuilder;
 import org.hypertrace.core.graphql.common.request.FilterRequestBuilder;
 import org.hypertrace.core.graphql.common.request.ResultSetRequest;
 import org.hypertrace.core.graphql.common.request.ResultSetRequestBuilder;
@@ -60,10 +63,12 @@ class DefaultEntityJoinerBuilderTest {
   @Mock ArgumentDeserializer mockDeserializer;
   @Mock ResultSetRequestBuilder mockResultSetRequestBuilder;
   @Mock FilterRequestBuilder mockFilterRequestBuilder;
+  @Mock AttributeRequestBuilder attributeRequestBuilder;
   @Mock GraphQlRequestContext mockRequestContext;
   @Mock DataFetchingFieldSelectionSet mockSelectionSet;
   @Mock AttributeAssociation<FilterArgument> mockFilter;
   @Mock ResultSetRequest mockResultSetRequest;
+  @Mock AttributeRequest mockAttributeRequest;
 
   Scheduler testScheduler = Schedulers.single();
 
@@ -78,6 +83,7 @@ class DefaultEntityJoinerBuilderTest {
             mockDeserializer,
             mockResultSetRequestBuilder,
             mockFilterRequestBuilder,
+            attributeRequestBuilder,
             testScheduler);
   }
 
@@ -118,6 +124,7 @@ class DefaultEntityJoinerBuilderTest {
             List.of(firstTypeFirstIdEntity, firstTypeSecondIdEntity),
             SECOND_ENTITY_TYPE,
             List.of(secondTypeFirstIdEntity, secondTypeSecondIdEntity)));
+    mockLabelAttributeRequest();
 
     EntityJoiner joiner =
         this.entityJoinerBuilder
@@ -214,6 +221,12 @@ class DefaultEntityJoinerBuilderTest {
 
               return Single.error(new UnsupportedOperationException());
             });
+  }
+
+  private void mockLabelAttributeRequest() {
+    doReturn(Single.just(mockAttributeRequest))
+        .when(attributeRequestBuilder)
+        .buildForKey(any(), any(), any());
   }
 
   @Value

--- a/hypertrace-graphql-labels-schema/src/main/java/org/hypertrace/graphql/label/joiner/DefaultLabelJoinerBuilder.java
+++ b/hypertrace-graphql-labels-schema/src/main/java/org/hypertrace/graphql/label/joiner/DefaultLabelJoinerBuilder.java
@@ -79,16 +79,17 @@ class DefaultLabelJoinerBuilder implements LabelJoinerBuilder {
     private Single<List<Label>> filterLabels(List<String> labelIds, Map<String, Label> labelMap) {
       return Single.just(
           labelIds.stream()
-              .map(
-                  labelId -> {
-                    Label label = labelMap.get(labelId);
-                    if (label == null) {
-                      log.warn("Label config doesn't exist for label id {}", labelId);
-                    }
-                    return label;
-                  })
+              .map(labelId -> getLabelFromMap(labelId, labelMap))
               .filter(Objects::nonNull)
               .collect(Collectors.toUnmodifiableList()));
+    }
+
+    private Label getLabelFromMap(String labelId, Map<String, Label> labelMap) {
+      Label label = labelMap.get(labelId);
+      if (label == null) {
+        log.warn("Label config doesn't exist for label id {}", labelId);
+      }
+      return label;
     }
   }
 }


### PR DESCRIPTION
1. Updated entity joiner request builder to fetch labels
2. No change needed in NeighborEntitiesRequestBuilder as it is called from DefaultEntityRequestBuilder which handles labels fetching part
3. Minor refactoring