### PR TITLE
Added build method with explorerScope in ExploreRequestBuilder

### DIFF
--- a/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/request/DefaultExploreRequestBuilder.java
+++ b/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/request/DefaultExploreRequestBuilder.java
@@ -83,7 +83,8 @@ class DefaultExploreRequestBuilder implements ExploreRequestBuilder {
     return this.build(requestContext, explorerScope, arguments, selectionSet);
   }
 
-  private Single<ExploreRequest> build(
+  @Override
+  public Single<ExploreRequest> build(
       GraphQlRequestContext requestContext,
       String explorerScope,
       Map<String, Object> arguments,

--- a/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/request/ExploreRequestBuilder.java
+++ b/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/request/ExploreRequestBuilder.java
@@ -10,4 +10,10 @@ public interface ExploreRequestBuilder {
       GraphQlRequestContext context,
       Map<String, Object> arguments,
       DataFetchingFieldSelectionSet selectionSet);
+
+  Single<ExploreRequest> build(
+      GraphQlRequestContext requestContext,
+      String explorerScope,
+      Map<String, Object> arguments,
+      DataFetchingFieldSelectionSet selectionSet);
 }


### PR DESCRIPTION
Explore API is now being used as part of other APIs too (like events) which do not inherently support many of the functionalities that `explore` does..
One requirement is to build the request using pre-defined scope instead of taking its value as argument.
Hence made the overloaded `build` method public which takes the `explorerScope` as one of the parameters.
