### PR TITLE
Added build method for explore-request-builder

### DIFF
--- a/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/request/ExploreRequestBuilder.java
+++ b/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/request/ExploreRequestBuilder.java
@@ -2,12 +2,36 @@ package org.hypertrace.graphql.explorer.request;
 
 import graphql.schema.DataFetchingFieldSelectionSet;
 import io.reactivex.rxjava3.core.Single;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.hypertrace.core.graphql.common.request.AttributeRequest;
+import org.hypertrace.core.graphql.common.schema.arguments.TimeRangeArgument;
+import org.hypertrace.core.graphql.common.schema.results.arguments.filter.FilterArgument;
 import org.hypertrace.core.graphql.context.GraphQlRequestContext;
+import org.hypertrace.graphql.explorer.schema.argument.GroupByArgument;
+import org.hypertrace.graphql.explorer.schema.argument.IntervalArgument;
+import org.hypertrace.graphql.metric.request.MetricAggregationRequest;
+import org.hypertrace.graphql.metric.schema.argument.AggregatableOrderArgument;
 
 public interface ExploreRequestBuilder {
   Single<ExploreRequest> build(
       GraphQlRequestContext context,
       Map<String, Object> arguments,
       DataFetchingFieldSelectionSet selectionSet);
+
+  Single<ExploreRequest> build(
+      GraphQlRequestContext requestContext,
+      String explorerScope,
+      TimeRangeArgument timeRange,
+      Optional<String> spaceId,
+      int limit,
+      int offset,
+      List<FilterArgument> requestedFilters,
+      List<AggregatableOrderArgument> requestedOrders,
+      Optional<GroupByArgument> groupBy,
+      Optional<IntervalArgument> intervalArgument,
+      Single<Set<AttributeRequest>> attributeSelections,
+      Single<Set<MetricAggregationRequest>> aggregationSelections);
 }


### PR DESCRIPTION
Explore API is now being used as part of other APIs too (like events) which do not inherently support many of the functionalities that explore does..
One requirement is to build the request using pre-defined scope and manipulating the arguments instead of using the user-entered arguments as is.
Hence, added an overloaded build method which takes all the arguments as parameters.