### PR TITLE
refactor: use container provided channel registry

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -53,8 +53,8 @@ jobs:
         if: always()
      
       - name: Publish Unit Test Results
-        uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1.6
+        uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v2
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: ./**/build/test-results/**/*.xml
+          junit_files: ./**/build/test-results/**/*.xml

--- a/.snyk
+++ b/.snyk
@@ -5,6 +5,6 @@ ignore:
   SNYK-JAVA-IONETTY-1042268:
     - '*':
         reason: No replacement available
-        expires: 2022-07-31T00:00:00.000Z
+        expires: 2022-10-31T00:00:00.000Z
 patch: {}
 

--- a/hypertrace-graphql-impl/build.gradle.kts
+++ b/hypertrace-graphql-impl/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
   api("org.hypertrace.core.graphql:hypertrace-core-graphql-spi")
   api("com.graphql-java-kickstart:graphql-java-servlet")
   api(project(":hypertrace-graphql-service-config"))
+  api("org.hypertrace.core.grpcutils:grpc-client-utils")
 
   implementation("org.hypertrace.core.graphql:hypertrace-core-graphql-schema-registry")
   implementation("org.hypertrace.core.graphql:hypertrace-core-graphql-context")

--- a/hypertrace-graphql-impl/src/main/java/org/hypertrace/graphql/impl/GraphQlFactory.java
+++ b/hypertrace-graphql-impl/src/main/java/org/hypertrace/graphql/impl/GraphQlFactory.java
@@ -6,12 +6,16 @@ import graphql.kickstart.servlet.GraphQLConfiguration;
 import graphql.schema.GraphQLSchema;
 import org.hypertrace.core.graphql.context.GraphQlRequestContextBuilder;
 import org.hypertrace.core.graphql.spi.lifecycle.GraphQlServiceLifecycle;
+import org.hypertrace.core.grpcutils.client.GrpcChannelRegistry;
 import org.hypertrace.graphql.config.HypertraceGraphQlServiceConfig;
 
 public class GraphQlFactory {
   public static GraphQLConfiguration build(
-      HypertraceGraphQlServiceConfig config, GraphQlServiceLifecycle serviceLifecycle) {
-    final Injector injector = Guice.createInjector(new GraphQlModule(config, serviceLifecycle));
+      HypertraceGraphQlServiceConfig config,
+      GraphQlServiceLifecycle serviceLifecycle,
+      GrpcChannelRegistry grpcChannelRegistry) {
+    final Injector injector =
+        Guice.createInjector(new GraphQlModule(config, serviceLifecycle, grpcChannelRegistry));
 
     return GraphQLConfiguration.with(injector.getInstance(GraphQLSchema.class))
         .with(injector.getInstance(GraphQlRequestContextBuilder.class))

--- a/hypertrace-graphql-impl/src/main/java/org/hypertrace/graphql/impl/GraphQlModule.java
+++ b/hypertrace-graphql-impl/src/main/java/org/hypertrace/graphql/impl/GraphQlModule.java
@@ -19,6 +19,7 @@ import org.hypertrace.core.graphql.trace.TraceSchemaModule;
 import org.hypertrace.core.graphql.utils.gateway.GatewayUtilsModule;
 import org.hypertrace.core.graphql.utils.grpc.GraphQlGrpcModule;
 import org.hypertrace.core.graphql.utils.schema.SchemaUtilsModule;
+import org.hypertrace.core.grpcutils.client.GrpcChannelRegistry;
 import org.hypertrace.graphql.atttribute.scopes.HypertraceAttributeScopeModule;
 import org.hypertrace.graphql.config.HypertraceGraphQlServiceConfig;
 import org.hypertrace.graphql.entity.EntityIdModule;
@@ -37,10 +38,15 @@ class GraphQlModule extends AbstractModule {
   private final HypertraceGraphQlServiceConfig config;
   private final GraphQlServiceLifecycle serviceLifecycle;
 
+  private final GrpcChannelRegistry grpcChannelRegistry;
+
   public GraphQlModule(
-      final HypertraceGraphQlServiceConfig config, final GraphQlServiceLifecycle serviceLifecycle) {
+      final HypertraceGraphQlServiceConfig config,
+      final GraphQlServiceLifecycle serviceLifecycle,
+      final GrpcChannelRegistry grpcChannelRegistry) {
     this.config = config;
     this.serviceLifecycle = serviceLifecycle;
+    this.grpcChannelRegistry = grpcChannelRegistry;
   }
 
   @Override
@@ -50,7 +56,7 @@ class GraphQlModule extends AbstractModule {
     bind(GraphQlServiceLifecycle.class).toInstance(this.serviceLifecycle);
     bind(Clock.class).toInstance(Clock.systemUTC());
     install(new GraphQlRequestContextModule());
-    install(new GraphQlGrpcModule());
+    install(new GraphQlGrpcModule(this.grpcChannelRegistry));
     install(new GraphQlSchemaRegistryModule());
     install(new GraphQlDeserializationRegistryModule());
     install(new HypertraceAttributeScopeModule());

--- a/hypertrace-graphql-impl/src/test/java/org/hypertrace/graphql/impl/GraphQlModuleTest.java
+++ b/hypertrace-graphql-impl/src/test/java/org/hypertrace/graphql/impl/GraphQlModuleTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 
 import com.google.inject.Guice;
 import org.hypertrace.core.graphql.spi.lifecycle.GraphQlServiceLifecycle;
+import org.hypertrace.core.grpcutils.client.GrpcChannelRegistry;
 import org.hypertrace.graphql.config.HypertraceGraphQlServiceConfig;
 import org.junit.jupiter.api.Test;
 
@@ -17,7 +18,8 @@ public class GraphQlModuleTest {
             Guice.createInjector(
                     new GraphQlModule(
                         mock(HypertraceGraphQlServiceConfig.class),
-                        mock(GraphQlServiceLifecycle.class)))
+                        mock(GraphQlServiceLifecycle.class),
+                        mock(GrpcChannelRegistry.class)))
                 .getAllBindings());
   }
 }

--- a/hypertrace-graphql-service/src/main/java/org/hypertrace/graphql/service/GraphQlServiceFactory.java
+++ b/hypertrace-graphql-service/src/main/java/org/hypertrace/graphql/service/GraphQlServiceFactory.java
@@ -25,7 +25,10 @@ public class GraphQlServiceFactory implements HttpHandlerFactory {
             .port(config.getServicePort())
             .contextPath(config.getGraphQlUrlPath())
             .corsConfig(buildCorsConfig(config))
-            .servlet(new GraphQlServiceHttpServlet(GraphQlFactory.build(config, serviceLifecycle)))
+            .servlet(
+                new GraphQlServiceHttpServlet(
+                    GraphQlFactory.build(
+                        config, serviceLifecycle, environment.getChannelRegistry())))
             .build());
   }
 


### PR DESCRIPTION
## Description
Consume refactor to use the container's channel registry rather than building our own internally
Depends on https://github.com/hypertrace/hypertrace-core-graphql/pull/106