### PR TITLE
fix: send alias on order by expression

### DIFF
--- a/hypertrace-graphql-gateway-service-metric-utils/src/main/java/org/hypertrace/graphql/utils/metrics/gateway/GatewayMetricUtilsModule.java
+++ b/hypertrace-graphql-gateway-service-metric-utils/src/main/java/org/hypertrace/graphql/utils/metrics/gateway/GatewayMetricUtilsModule.java
@@ -24,6 +24,7 @@ import org.hypertrace.gateway.service.v1.common.TimeAggregation;
 import org.hypertrace.gateway.service.v1.common.Value;
 import org.hypertrace.gateway.service.v1.entity.Entity;
 import org.hypertrace.graphql.metric.request.MetricAggregationRequest;
+import org.hypertrace.graphql.metric.request.MetricAggregationRequestBuilder;
 import org.hypertrace.graphql.metric.request.MetricRequest;
 import org.hypertrace.graphql.metric.request.MetricSeriesRequest;
 import org.hypertrace.graphql.metric.schema.BaselinedMetricAggregationContainer;
@@ -76,5 +77,6 @@ public class GatewayMetricUtilsModule extends AbstractModule {
         Key.get(
             new TypeLiteral<
                 Converter<MetricAggregationType, AttributeModelMetricAggregationType>>() {}));
+    requireBinding(MetricAggregationRequestBuilder.class);
   }
 }

--- a/hypertrace-graphql-gateway-service-metric-utils/src/main/java/org/hypertrace/graphql/utils/metrics/gateway/MetricAggregationExpressionConverter.java
+++ b/hypertrace-graphql-gateway-service-metric-utils/src/main/java/org/hypertrace/graphql/utils/metrics/gateway/MetricAggregationExpressionConverter.java
@@ -2,11 +2,9 @@ package org.hypertrace.graphql.utils.metrics.gateway;
 
 import static io.reactivex.rxjava3.core.Single.zip;
 
-import com.google.protobuf.StringValue;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -49,25 +47,6 @@ class MetricAggregationExpressionConverter
             metricAggregation.aggregation(),
             metricAggregation.arguments(),
             alias)
-        .map(functionExpression -> Expression.newBuilder().setFunction(functionExpression).build());
-  }
-
-  Single<Expression> convertForNoArgsOrAlias(
-      AttributeAssociation<AttributeExpression> attributeExpressionAssociation,
-      AttributeModelMetricAggregationType aggregationType) {
-    return convertForArgsButNoAlias(
-        attributeExpressionAssociation, aggregationType, Collections.emptyList());
-  }
-
-  Single<Expression> convertForArgsButNoAlias(
-      AttributeAssociation<AttributeExpression> attributeExpressionAssociation,
-      AttributeModelMetricAggregationType aggregationType,
-      List<Object> arguments) {
-    return this.buildAggregationFunctionExpression(
-            attributeExpressionAssociation,
-            aggregationType,
-            arguments,
-            StringValue.getDefaultInstance().getValue())
         .map(functionExpression -> Expression.newBuilder().setFunction(functionExpression).build());
   }
 


### PR DESCRIPTION
## Description

This is a bandaid for a gateway service bug that requires a more involved fix. Gateway service makes an assumption that the alias for an order by expression will match the column it's ordering by when being applied in memory such as an entity-explorer query. We should break that assumption, but for now abiding by it by using the same alias generation code.
