### PR TITLE
fix(entities): support for API filters for filtered data specs

### DIFF
--- a/hypertrace-graphql-entity-schema/build.gradle.kts
+++ b/hypertrace-graphql-entity-schema/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
   implementation(commonLibs.hypertrace.grpcutils.client)
   implementation(projects.hypertraceGraphqlLabelsSchemaApi)
 
+  implementation(localLibs.core.request.transformation)
   implementation(localLibs.core.context)
   implementation(localLibs.core.grpc)
   implementation(localLibs.core.schema.utils)

--- a/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/dao/GatewayServiceEntityDao.java
+++ b/hypertrace-graphql-entity-schema/src/main/java/org/hypertrace/graphql/entity/dao/GatewayServiceEntityDao.java
@@ -45,7 +45,6 @@ class GatewayServiceEntityDao implements EntityDao {
   private final GraphQlServiceConfig serviceConfig;
   private final Scheduler boundedIoScheduler;
   private final LabelJoinerBuilder labelJoinerBuilder;
-
   private final RequestTransformer requestTransformer;
 
   @Inject


### PR DESCRIPTION
Add support for `apiFilters` for `filteredDataSpecs`. Entity query transformation was missing the request transformation to transform the request based on the `apiFilters` in `filteredDataSpecs`