### PR TITLE
chore | revert passing the alias in case of aggregations and create default alias without dot

### DIFF
--- a/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/request/ExploreSelectionRequestBuilder.java
+++ b/hypertrace-graphql-explorer-schema/src/main/java/org/hypertrace/graphql/explorer/request/ExploreSelectionRequestBuilder.java
@@ -119,8 +119,7 @@ class ExploreSelectionRequestBuilder {
                 new SelectionArguments(
                     attributeExpression,
                     aggregationType,
-                    this.getArguments(selectedField, aggregationType),
-                    selectedField.getAlias()))
+                    this.getArguments(selectedField, aggregationType)))
         .orElse(new SelectionArguments(attributeExpression));
   }
 
@@ -146,8 +145,7 @@ class ExploreSelectionRequestBuilder {
                 this.aggregationRequestBuilder.build(
                     attributeExpressionAttributeAssociation,
                     arguments.getAggregationType(),
-                    arguments.getAggregationArguments(),
-                    arguments.getAlias()));
+                    arguments.getAggregationArguments()));
   }
 
   private List<Object> getArguments(
@@ -190,35 +188,16 @@ class ExploreSelectionRequestBuilder {
     @Nonnull AttributeExpression attributeExpression;
     @Nullable AttributeModelMetricAggregationType aggregationType;
     @Nullable List<Object> aggregationArguments;
-    @Nullable String alias;
 
     SelectionArguments(AttributeExpression attributeExpression) {
-      this(SelectionType.ATTRIBUTE, attributeExpression, null, null, null);
+      this(SelectionType.ATTRIBUTE, attributeExpression, null, null);
     }
 
     SelectionArguments(
         AttributeExpression attributeExpression,
         AttributeModelMetricAggregationType aggregationType,
         List<Object> aggregationArguments) {
-      this(
-          SelectionType.AGGREGATION,
-          attributeExpression,
-          aggregationType,
-          aggregationArguments,
-          null);
-    }
-
-    SelectionArguments(
-        AttributeExpression attributeExpression,
-        AttributeModelMetricAggregationType aggregationType,
-        List<Object> aggregationArguments,
-        String alias) {
-      this(
-          SelectionType.AGGREGATION,
-          attributeExpression,
-          aggregationType,
-          aggregationArguments,
-          alias);
+      this(SelectionType.AGGREGATION, attributeExpression, aggregationType, aggregationArguments);
     }
   }
 }

--- a/hypertrace-graphql-metric-schema/src/main/java/org/hypertrace/graphql/metric/request/DefaultMetricAggregationRequestBuilder.java
+++ b/hypertrace-graphql-metric-schema/src/main/java/org/hypertrace/graphql/metric/request/DefaultMetricAggregationRequestBuilder.java
@@ -80,25 +80,16 @@ class DefaultMetricAggregationRequestBuilder implements MetricAggregationRequest
       AttributeAssociation<AttributeExpression> attributeExpressionAssociation,
       AttributeModelMetricAggregationType aggregationType,
       List<Object> arguments) {
-    return this.build(attributeExpressionAssociation, aggregationType, arguments, false, null);
-  }
-
-  public MetricAggregationRequest build(
-      AttributeAssociation<AttributeExpression> attributeExpressionAssociation,
-      AttributeModelMetricAggregationType aggregationType,
-      List<Object> arguments,
-      String alias) {
-    return this.build(attributeExpressionAssociation, aggregationType, arguments, false, alias);
+    return this.build(attributeExpressionAssociation, aggregationType, arguments, false);
   }
 
   private MetricAggregationRequest build(
       AttributeAssociation<AttributeExpression> attributeExpressionAssociation,
       AttributeModelMetricAggregationType aggregationType,
       List<Object> arguments,
-      boolean baseline,
-      String alias) {
+      boolean baseline) {
     return new DefaultMetricAggregationRequest(
-        attributeExpressionAssociation, aggregationType, arguments, baseline, alias);
+        attributeExpressionAssociation, aggregationType, arguments, baseline);
   }
 
   private MetricAggregationRequest requestForAggregationField(
@@ -114,8 +105,7 @@ class DefaultMetricAggregationRequestBuilder implements MetricAggregationRequest
             .findSelections(
                 field.getSelectionSet(), SelectionQuery.namedChild(BASELINE_AGGREGATION_VALUE))
             .findAny()
-            .isPresent(),
-        field.getAlias());
+            .isPresent());
   }
 
   private Optional<AttributeModelMetricAggregationType> getAggregationTypeForField(
@@ -191,14 +181,9 @@ class DefaultMetricAggregationRequestBuilder implements MetricAggregationRequest
     AttributeModelMetricAggregationType aggregation;
     List<Object> arguments;
     boolean baseline;
-    String alias;
 
     @Override
     public String alias() {
-      if (alias != null) {
-        return alias;
-      }
-
       return String.format(
           "%s_%s_%s",
           this.aggregation.name(),

--- a/hypertrace-graphql-metric-schema/src/main/java/org/hypertrace/graphql/metric/request/DefaultMetricAggregationRequestBuilder.java
+++ b/hypertrace-graphql-metric-schema/src/main/java/org/hypertrace/graphql/metric/request/DefaultMetricAggregationRequestBuilder.java
@@ -184,10 +184,15 @@ class DefaultMetricAggregationRequestBuilder implements MetricAggregationRequest
 
     @Override
     public String alias() {
+      // We have purposefully removed attribute().getId()
+      // because id contains dot(.) which messes up with
+      // database operations because we need to encode dot
+      // at multiple places and it causes data alias mismatch.
       return String.format(
-          "%s_%s_%s",
+          "%s_%s_%s_%s",
           this.aggregation.name(),
-          this.attributeExpressionAssociation.attribute().id(),
+          this.attributeExpressionAssociation.attribute().scope(),
+          this.attributeExpressionAssociation.attribute().key(),
           this.arguments);
     }
 

--- a/hypertrace-graphql-metric-schema/src/main/java/org/hypertrace/graphql/metric/request/MetricAggregationRequestBuilder.java
+++ b/hypertrace-graphql-metric-schema/src/main/java/org/hypertrace/graphql/metric/request/MetricAggregationRequestBuilder.java
@@ -24,10 +24,4 @@ public interface MetricAggregationRequestBuilder {
       AttributeAssociation<AttributeExpression> attributeExpressionAssociation,
       AttributeModelMetricAggregationType aggregationType,
       List<Object> arguments);
-
-  MetricAggregationRequest build(
-      AttributeAssociation<AttributeExpression> attributeExpressionAssociation,
-      AttributeModelMetricAggregationType aggregationType,
-      List<Object> arguments,
-      String alias);
 }


### PR DESCRIPTION
Reverts hypertrace/hypertrace-graphql#235